### PR TITLE
Vault cert provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ class { 'vault_secrets::vault_cert':
 }
 ```
 
+`vault_cert` resources will autorequire any `File` resources coresponding to
+the parent directories of the `ca_chain_file`, `cert_file` and `key_file` properties. Any `User` or `Group` resources corresponding to the `*_owner` or `*_group` properties will also be autorequired.
+
 ## Limitations
 
 Should work with all supported releases of Puppet server, but has been only minimally tested.  Deferred functinos require

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Description
 
-This module provides functions to integrate Hashicorp Vault with Puppet and uses the main module class to enable
+This module provides functions and type/providers to integrate Hashicorp Vault with Puppet and uses the main module class to enable
 issuing and renewing host certificates from a Vault PKI secrets engine.  The module has no dependencies other than
 'puppetlabs-stdlib' and requires no extra ruby gems on the Puppet server or agents.  If you only want to use the
 functions without issuing host certificates from Vault, add the module to an environment without assigning it to
@@ -26,6 +26,10 @@ The `vault_hash` and `vault_key` functions also support Vault key/value secrets 
 be used in manifests to get secrets from Vault.  With Puppet agents 6 and later you can also use
 [deferred functions](https://puppet.com/docs/puppet/latest/deferred_functions.html) to enable clients to get
 secrets directly from Vault without passing them through the Puppet server.
+
+The `vault_cert` resource type can be used to manage TLS certificates for use by other applications.
+These are issued by Vault directly to agents (private keys are not stored on puppet servers or in the catalog),
+and renewed automatically as needed.
 
 ## Setup
 
@@ -196,6 +200,57 @@ hierarchy:
       timeout: 3
       auth_path: "puppet-pki"
       ca_trust: "/etc/ssl/certs/ca-certificates.crt"
+```
+### Vault-issued certificates
+
+Include the `vault_secrets::vault_cert` class to ensure required directories are created
+and then use the `vault_cert` resource type for each certificate you wish to manage.
+This resource will authenticate to vault using the agent's Puppet certificate, and write
+the key, certificate and chain files so they can be consumed by another application.
+The private key is written only on the agent, and is not revealed to the puppet server
+or included in the catalog.
+
+Certificates will be renewed automatically when puppet runs and there are fewer days
+remaining than the `renewal_threshold` parameter is set to, or if the certificate is
+found to already be expired.
+
+By default, all files are written to the directory specified by the `$::vault_cert_dir`
+fact, however the issued certificate and key files can be written to arbitrary locations.
+File ownership and permissions can also be customised as shown below.
+
+```puppet
+include vault_secrets::vault_cert
+
+vault_cert { 'test':
+  ensure            => present,
+  vault_uri         => 'https://vault.example.com:8200/pki/issue/role',
+  cert_data         => {
+    'common_name' => 'test.example.com',
+    'alt_names'   => ['alias.exmaple.com', 'localhost'].join('\n'),
+    'ip_sans'     => [$::facts['networking']['ip'], '127.0.0.1'],
+    'ttl'         => '2160h', # 90 days
+  },
+  # Optional
+  renewal_threshold => 5,
+  ca_chain_file     => '/srv/myapp/ca.crt',
+  ca_chain_owner    => 'myapp',
+  ca_chain_group    => 'myapp',
+  cert_file         => '/srv/myapp/server.crt',
+  cert_owner        => 'myapp',
+  cert_group        => 'myapp',
+  key_file          => '/srv/myapp/server.key',
+  key_owner         => 'myapp',
+  key_group         => 'myapp',
+}
+```
+
+You can purge certificates from the system which are no longer included in the puppet
+catalog by setting `vault_sercrets::vault_cert::purge: true` in hiera, or like the below:
+
+```puppet
+class { 'vault_secrets::vault_cert':
+  purge => true,
+}
 ```
 
 ## Limitations

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,6 +7,11 @@
 ### Classes
 
 * [`vault_secrets`](#vault_secrets): Issue and renew PKI certificates from Hashicorp Vault
+* [`vault_secrets::vault_cert`](#vault_secretsvault_cert)
+
+### Resource types
+
+* [`vault_cert`](#vault_cert): A type representing a certificate issued by Hashicorp Vault
 
 ### Functions
 
@@ -17,7 +22,7 @@
 
 ## Classes
 
-### `vault_secrets`
+### <a name="vault_secrets"></a>`vault_secrets`
 
 Issue and renew PKI certificates from Hashicorp Vault
 
@@ -34,21 +39,26 @@ class { 'vault_secrets':
 
 #### Parameters
 
-The following parameters are available in the `vault_secrets` class.
+The following parameters are available in the `vault_secrets` class:
 
-##### `vault_uri`
+* [`vault_uri`](#vault_uri)
+* [`auth_path`](#auth_path)
+* [`days_before_renewal`](#days_before_renewal)
+* [`cert_data`](#cert_data)
+
+##### <a name="vault_uri"></a>`vault_uri`
 
 Data type: `String`
 
 The complete URL of the the Hashicorp Vault certificate issuing role API endpoint
 
-##### `auth_path`
+##### <a name="auth_path"></a>`auth_path`
 
 Data type: `String`
 
 The Vault path of the authentication provider used by Puppet certificates
 
-##### `days_before_renewal`
+##### <a name="days_before_renewal"></a>`days_before_renewal`
 
 Data type: `Integer[1, 30]`
 
@@ -56,7 +66,7 @@ The number of days before expiration where the host certificate will be re-issue
 
 Default value: `3`
 
-##### `cert_data`
+##### <a name="cert_data"></a>`cert_data`
 
 Data type: `Hash`
 
@@ -66,9 +76,233 @@ defined in module hiera.
 
 Default value: `{}`
 
+### <a name="vault_secretsvault_cert"></a>`vault_secrets::vault_cert`
+
+The vault_secrets::vault_cert class.
+
+#### Parameters
+
+The following parameters are available in the `vault_secrets::vault_cert` class:
+
+* [`purge`](#purge)
+
+##### <a name="purge"></a>`purge`
+
+Data type: `Any`
+
+
+
+Default value: ``false``
+
+## Resource types
+
+### <a name="vault_cert"></a>`vault_cert`
+
+A type representing a certificate issued by Hashicorp Vault
+
+#### Properties
+
+The following properties are available in the `vault_cert` type.
+
+##### `ca_chain`
+
+Valid values: `auto`
+
+Read-only property which contains the value of the CA chain
+
+Default value: `auto`
+
+##### `ca_chain_file`
+
+Where the CA chain file should be written
+
+##### `ca_chain_group`
+
+The group which the ca_chain_file should be owned by
+
+Default value: `root`
+
+##### `ca_chain_mode`
+
+The file mode the ca_chain_file should be written with
+
+Default value: `0644`
+
+##### `ca_chain_owner`
+
+The user which the ca_chain_file should be owned by
+
+Default value: `root`
+
+##### `cert`
+
+Valid values: `auto`
+
+Read-only property which contains the value of the certificate
+
+Default value: `auto`
+
+##### `cert_data`
+
+The attributes of the certificate to be issued
+
+##### `cert_file`
+
+Where the certificate file should be written
+
+##### `cert_group`
+
+The group which the cert_file should be owned by
+
+Default value: `root`
+
+##### `cert_mode`
+
+The file mode the cert _file should be written with
+
+Default value: `0644`
+
+##### `cert_owner`
+
+The user which the cert_file should be owned by
+
+Default value: `root`
+
+##### `ensure`
+
+Valid values: `present`, `absent`
+
+The basic property that the resource should be in.
+
+Default value: `present`
+
+##### `expiration`
+
+Valid values: `auto`
+
+Read-only property showing the expiration time of the certificate
+
+Default value: `auto`
+
+##### `info_ca_chain`
+
+Valid values: `auto`
+
+Read-only property which contains the value of the CA chain from the info file
+
+Default value: `auto`
+
+##### `info_cert`
+
+Valid values: `auto`
+
+Read-only property which contains the value of the cerificate from the info file
+
+Default value: `auto`
+
+##### `info_group`
+
+The group which the info_file should be owned by
+
+Default value: `root`
+
+##### `info_key`
+
+Valid values: `auto`
+
+Read-only property which contains the value of the private key from the info file
+
+Default value: `auto`
+
+##### `info_mode`
+
+The file mode the info_file should be written with
+
+Default value: `0600`
+
+##### `info_owner`
+
+The user which the info_file should be owned by
+
+Default value: `root`
+
+##### `key`
+
+Valid values: `auto`
+
+Read-only property which contains the value of the privat ekey
+
+Default value: `auto`
+
+##### `key_file`
+
+Where the key file should be written
+
+##### `key_group`
+
+The group which the key_file should be owned by
+
+Default value: `root`
+
+##### `key_mode`
+
+The file mode the key file should be written with
+
+Default value: `0600`
+
+##### `key_owner`
+
+The user which the key_file should be owned by
+
+Default value: `root`
+
+#### Parameters
+
+The following parameters are available in the `vault_cert` type.
+
+* [`auth_path`](#auth_path)
+* [`name`](#name)
+* [`provider`](#provider)
+* [`renewal_threshold`](#renewal_threshold)
+* [`timeout`](#timeout)
+* [`vault_uri`](#vault_uri)
+
+##### <a name="auth_path"></a>`auth_path`
+
+The path used to authenticate puppet agent to vault
+
+Default value: `puppet-pki`
+
+##### <a name="name"></a>`name`
+
+namevar
+
+The name of the certificate
+
+##### <a name="provider"></a>`provider`
+
+The specific backend to use for this `vault_cert` resource. You will seldom need to specify this --- Puppet will usually
+discover the appropriate provider for your platform.
+
+##### <a name="renewal_threshold"></a>`renewal_threshold`
+
+Certificate should be renewed when fewer than this many days remain before expiry
+
+Default value: `3`
+
+##### <a name="timeout"></a>`timeout`
+
+Length of time to wait on vault connections
+
+Default value: `5`
+
+##### <a name="vault_uri"></a>`vault_uri`
+
+The full URI of the vault PKI secrets engine
+
 ## Functions
 
-### `vault_cert`
+### <a name="vault_cert"></a>`vault_cert`
 
 Type: Ruby 4.x API
 
@@ -105,7 +339,7 @@ Data type: `Optional[Integer]`
 
 Value in seconds to wait for Vault connections.  Default is 5.
 
-### `vault_hash`
+### <a name="vault_hash"></a>`vault_hash`
 
 Type: Ruby 4.x API
 
@@ -141,7 +375,7 @@ Data type: `Optional[Integer]`
 
 Value in seconds to wait for Vault connections.
 
-### `vault_hiera_hash`
+### <a name="vault_hiera_hash"></a>`vault_hiera_hash`
 
 Type: Ruby 4.x API
 
@@ -165,7 +399,7 @@ Data type: `Puppet::LookupContext`
 
 Unused. The function will raise an error if Vault lookup fails
 
-### `vault_key`
+### <a name="vault_key"></a>`vault_key`
 
 Type: Ruby 4.x API
 

--- a/lib/facter/vault_cert_dir.rb
+++ b/lib/facter/vault_cert_dir.rb
@@ -1,0 +1,22 @@
+# @summary Structured fact about the managed host PKI certificate and private key
+
+require 'facter'
+require 'date'
+
+Facter.add(:vault_cert) do
+  confine osfamily: 'RedHat'
+
+  setcode do
+    '/etc/pki/vault-secerts'
+  end
+end
+
+Facter.add(:vault_cert) do
+  confine osfamily: 'Debian'
+
+  setcode do
+    '/etc/ssl/vault-secerts'
+  end
+end
+
+

--- a/lib/facter/vault_cert_dir.rb
+++ b/lib/facter/vault_cert_dir.rb
@@ -3,19 +3,19 @@
 require 'facter'
 require 'date'
 
-Facter.add(:vault_cert) do
+Facter.add(:vault_cert_dir) do
   confine osfamily: 'RedHat'
 
   setcode do
-    '/etc/pki/vault-secerts'
+    '/etc/pki/vault-secrets'
   end
 end
 
-Facter.add(:vault_cert) do
+Facter.add(:vault_cert_dir) do
   confine osfamily: 'Debian'
 
   setcode do
-    '/etc/ssl/vault-secerts'
+    '/etc/ssl/vault-secrets'
   end
 end
 

--- a/lib/facter/vault_cert_dir.rb
+++ b/lib/facter/vault_cert_dir.rb
@@ -18,5 +18,3 @@ Facter.add(:vault_cert_dir) do
     '/etc/ssl/vault-secrets'
   end
 end
-
-

--- a/lib/puppet/provider/vault_cert/ruby.rb
+++ b/lib/puppet/provider/vault_cert/ruby.rb
@@ -80,7 +80,6 @@ Puppet::Type.type(:vault_cert).provide(:ruby) do
   end
 
   def exists?
-    Puppet.info("property_hash includes ensure? #{@property_hash.include?(:ensure)}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/vault_cert/ruby.rb
+++ b/lib/puppet/provider/vault_cert/ruby.rb
@@ -4,330 +4,326 @@ require 'json'
 require "#{File.dirname(__FILE__)}/../../shared/vault_common.rb"
 
 Puppet::Type.type(:vault_cert).provide(:ruby) do
-	desc 'Issue certificates from Hashicorp Vault'
+  desc 'Issue certificates from Hashicorp Vault'
 
-	mk_resource_methods
+  mk_resource_methods
 
-	def initialize(value={})
-		super(value)
-		@cert_dir = Facter.value(:vault_cert_dir)
-		@property_flush = {}
-	end
+  def initialize(value = {})
+    super(value)
+    @cert_dir = Facter.value(:vault_cert_dir)
+    @property_flush = {}
+  end
 
-	def self.instances
-		instances = []
-		cert_dir = Facter.value(:vault_cert_dir)
-		cert_filenames = Dir.glob("#{cert_dir}/*.json")
-		cert_filenames.each do |info_file|
-			name = File.basename(info_file, '.json')
-			
-			info_content, info_owner, info_group, info_mode = load_file(info_file)
-			cert_info = JSON.parse(info_content)
+  def self.instances
+    instances = []
+    cert_dir = Facter.value(:vault_cert_dir)
+    cert_filenames = Dir.glob("#{cert_dir}/*.json")
+    cert_filenames.each do |info_file|
+      name = File.basename(info_file, '.json')
 
-			next unless ['data', 'cert_data', 'ca_chain_file', 'cert_file', 'key_file'].all? {|k| cert_info.key? k}
+      info_content, info_owner, info_group, info_mode = load_file(info_file)
+      cert_info = JSON.parse(info_content)
 
-			ca_chain, ca_chain_owner, ca_chain_group, ca_chain_mode = load_file(cert_info['ca_chain_file'])
-			cert, cert_owner, cert_group, cert_mode = load_file(cert_info['cert_file'])
-			key, key_owner, key_group, key_mode = load_file(cert_info['key_file'])
+      next unless ['data', 'cert_data', 'ca_chain_file', 'cert_file', 'key_file'].all? { |k| cert_info.key? k }
 
-			begin
-				expiration = cert_info['data']['expiration']
-			rescue
-				expiration = nil
-			end
+      ca_chain, ca_chain_owner, ca_chain_group, ca_chain_mode = load_file(cert_info['ca_chain_file'])
+      cert, cert_owner, cert_group, cert_mode = load_file(cert_info['cert_file'])
+      key, key_owner, key_group, key_mode = load_file(cert_info['key_file'])
 
-			instances << new(
-				ensure: :present,
-				name: name,
-				cert_data: cert_info['cert_data'],
-				expiration: expiration,
-				# Info file
-				info_owner: info_owner,
-				info_group: info_group,
-				info_mode: info_mode,
-				# CA Chain
-				ca_chain_file: cert_info['ca_chain_file'],
-				ca_chain_owner: ca_chain_owner,
-				ca_chain_group: ca_chain_group,
-				ca_chain_mode: ca_chain_mode,
-				ca_chain: ca_chain,
-				info_ca_chain: cert_info['data']['ca_chain'].join("\n"),
-				# Certificate
-				cert_file: cert_info['cert_file'],
-				cert_owner: cert_owner,
-				cert_group: cert_group,
-				cert_mode: cert_mode,
-				cert: cert,
-				info_cert: [cert_info['data']['certificate'], cert_info['data']['issuing_ca']].join("\n"),
-				# Private Key
-				key_file: cert_info['key_file'],
-				key_owner: key_owner,
-				key_group: key_group,
-				key_mode: key_mode,
-				key: key,
-				info_key: cert_info['data']['private_key']
-			)
-		end
-		return instances
-	end
+      begin
+        expiration = cert_info['data']['expiration']
+      rescue
+        expiration = nil
+      end
 
-	def self.prefetch(resources)
-		instances.each do |prov|
-			if (resource = resources[prov.name])
-			resource.provider = prov
-			end
-		end
-	end
+      instances << new(
+        ensure: :present,
+        name: name,
+        cert_data: cert_info['cert_data'],
+        expiration: expiration,
+        # Info file
+        info_owner: info_owner,
+        info_group: info_group,
+        info_mode: info_mode,
+        # CA Chain
+        ca_chain_file: cert_info['ca_chain_file'],
+        ca_chain_owner: ca_chain_owner,
+        ca_chain_group: ca_chain_group,
+        ca_chain_mode: ca_chain_mode,
+        ca_chain: ca_chain,
+        info_ca_chain: cert_info['data']['ca_chain'].join("\n"),
+        # Certificate
+        cert_file: cert_info['cert_file'],
+        cert_owner: cert_owner,
+        cert_group: cert_group,
+        cert_mode: cert_mode,
+        cert: cert,
+        info_cert: [cert_info['data']['certificate'], cert_info['data']['issuing_ca']].join("\n"),
+        # Private Key
+        key_file: cert_info['key_file'],
+        key_owner: key_owner,
+        key_group: key_group,
+        key_mode: key_mode,
+        key: key,
+        info_key: cert_info['data']['private_key'],
+      )
+    end
+    instances
+  end
 
-	def exists?
-		Puppet.info("property_hash includes ensure? #{@property_hash.include?(:ensure)}")
-		@property_hash[:ensure] == :present
-	end
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
+      end
+    end
+  end
 
-	def create
-		@property_flush[:ensure] = :present
-	end
+  def exists?
+    Puppet.info("property_hash includes ensure? #{@property_hash.include?(:ensure)}")
+    @property_hash[:ensure] == :present
+  end
 
-	def destroy
-		@property_flush[:ensure] = :absent
-	end
+  def create
+    @property_flush[:ensure] = :present
+  end
 
-	def self.get_ca_trust
-		# Try known paths for trusted CA certificate bundles
-		if File.exist?('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')
-			'/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
-		elsif File.exist?('/etc/ssl/certs/ca-certificates.crt')
-			'/etc/ssl/certs/ca-certificates.crt'
-		else
-			raise Puppet::Error, 'Failed to get the trusted CA certificate file'
-		end
-	end
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
 
-	def issue_cert
-		Puppet.info("Requesting certificate #{@resource[:name]}")
+  def self.get_ca_trust
+    # Try known paths for trusted CA certificate bundles
+    if File.exist?('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')
+      '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    elsif File.exist?('/etc/ssl/certs/ca-certificates.crt')
+      '/etc/ssl/certs/ca-certificates.crt'
+    else
+      raise Puppet::Error, 'Failed to get the trusted CA certificate file'
+    end
+  end
 
-		uri = URI(@resource[:vault_uri])
-		raise Puppet::Error, "Unable to parse a hostname from #{@resource[:vault_uri]}" unless uri.hostname
+  def issue_cert
+    Puppet.info("Requesting certificate #{@resource[:name]}")
 
-		ca_trust = self.class.get_ca_trust
+    uri = URI(@resource[:vault_uri])
+    raise Puppet::Error, "Unable to parse a hostname from #{@resource[:vault_uri]}" unless uri.hostname
 
-		http = http_create_secure(uri, ca_trust, @resource[:timeout])
-		token = vault_get_token(http, @resource[:auth_path].delete('/'))
-		secrets = vault_http_post(http, uri.path, token, @resource[:cert_data])
-		response = vault_parse_data(secrets)
+    ca_trust = self.class.get_ca_trust
 
-		return response
-	end
+    http = http_create_secure(uri, ca_trust, @resource[:timeout])
+    token = vault_get_token(http, @resource[:auth_path].delete('/'))
+    secrets = vault_http_post(http, uri.path, token, @resource[:cert_data])
+    response = vault_parse_data(secrets)
 
-	def self.load_file(file)
-		if file && File.exists?(file)
-			content = File.read(file)
-			stat = File::Stat.new(file)
-			owner = Etc.getpwuid(stat.uid).name
-			group = Etc.getgrgid(stat.gid).name
-			mode = sprintf("%04o", stat.mode & 07777)
-			return content, owner, group, mode
-		else
-			return nil, nil, nil, nil
-		end
-	end
+    response
+  end
 
-	def self.chown_file(file, owner, group)
-		uid = owner ? Etc.getpwnam(owner).uid : nil
-		gid = group ? Etc.getgrnam(group).gid : nil
-		unless uid.nil? and gid.nil?
-			File.chown(uid, gid, file)
-		end
-	end
+  def self.load_file(file)
+    if file && File.exist?(file)
+      content = File.read(file)
+      stat = File::Stat.new(file)
+      owner = Etc.getpwuid(stat.uid).name
+      group = Etc.getgrgid(stat.gid).name
+      mode = '%04o' % (stat.mode & 0o7777)
+      [content, owner, group, mode]
+    else
+      [nil, nil, nil, nil]
+    end
+  end
 
-	def self.chmod_file(file, mode)
-		File.chmod(mode.to_i(8), file) if mode
-	end
+  def self.chown_file(file, owner, group)
+    uid = owner ? Etc.getpwnam(owner).uid : nil
+    gid = group ? Etc.getgrnam(group).gid : nil
+    File.chown(uid, gid, file) unless uid.nil? && gid.nil?
+  end
 
-	def self.delete_if_exists(file)
-		File.delete(file) if ! file.to_s.empty? && File.exist?(file)
-	end
+  def self.chmod_file(file, mode)
+    File.chmod(mode.to_i(8), file) if mode
+  end
 
-	def expires_soon_or_expired
-		time_now = Time.now.to_i
-		expiry_time = @property_hash[:expiration]
-		renewal_threshold_seconds = @resource[:renewal_threshold] * 3600 * 24
-		renewal_time = expiry_time - renewal_threshold_seconds
-		return time_now >= renewal_time
-	end
+  def self.delete_if_exists(file)
+    File.delete(file) if !file.to_s.empty? && File.exist?(file)
+  end
 
-	def needs_issue?
-		return true if @property_hash[:ensure] != :present
-		return true if @property_flush.include?(:cert_data) && @property_hash[:cert_data] != @property_flush[:cert_data]
-		return true if expires_soon_or_expired
-		return false
-	end
+  def expires_soon_or_expired
+    time_now = Time.now.to_i
+    expiry_time = @property_hash[:expiration]
+    renewal_threshold_seconds = @resource[:renewal_threshold] * 3600 * 24
+    renewal_time = expiry_time - renewal_threshold_seconds
+    time_now >= renewal_time
+  end
 
-	def info_owner=(value)
-		@property_flush[:info_owner] = value
-	end
+  def needs_issue?
+    return true if @property_hash[:ensure] != :present
+    return true if @property_flush.include?(:cert_data) && @property_hash[:cert_data] != @property_flush[:cert_data]
+    return true if expires_soon_or_expired
+    false
+  end
 
-	def info_group=(value)
-		@property_flush[:info_group] = value
-	end
+  def info_owner=(value)
+    @property_flush[:info_owner] = value
+  end
 
-	def info_mode=(value)
-		@property_flush[:info_mode] = value
-	end
+  def info_group=(value)
+    @property_flush[:info_group] = value
+  end
 
-	def cert_data=(value)
-		@property_flush[:cert_data] = value
-	end
+  def info_mode=(value)
+    @property_flush[:info_mode] = value
+  end
 
-	def ca_chain_file=(value)
-		@property_flush[:ca_chain_file] = value
-	end
+  def cert_data=(value)
+    @property_flush[:cert_data] = value
+  end
 
-	def ca_chain_owner=(value)
-		@property_flush[:ca_chain_owner] = value
-	end
- 
-	def ca_chain_group=(value)
-		@property_flush[:ca_chain_group] = value
-	end
+  def ca_chain_file=(value)
+    @property_flush[:ca_chain_file] = value
+  end
 
-	def ca_chain_mode=(value)
-		@property_flush[:ca_chain_mode] = value
-	end
+  def ca_chain_owner=(value)
+    @property_flush[:ca_chain_owner] = value
+  end
 
-	def cert_file=(value)
-		@property_flush[:cert_file] = value
-	end
+  def ca_chain_group=(value)
+    @property_flush[:ca_chain_group] = value
+  end
 
-	def cert_owner=(value)
-		@property_flush[:cert_owner] = value
-	end
- 
-	def cert_group=(value)
-		@property_flush[:cert_group] = value
-	end
+  def ca_chain_mode=(value)
+    @property_flush[:ca_chain_mode] = value
+  end
 
-	def cert_mode=(value)
-		@property_flush[:cert_mode] = value
-	end
+  def cert_file=(value)
+    @property_flush[:cert_file] = value
+  end
 
-	def key_file=(value)
-		@property_flush[:key_file] = value
-	end
+  def cert_owner=(value)
+    @property_flush[:cert_owner] = value
+  end
 
-	def key_owner=(value)
-		@property_flush[:key_owner] = value
-	end
- 
-	def key_group=(value)
-		@property_flush[:key_group] = value
-	end
+  def cert_group=(value)
+    @property_flush[:cert_group] = value
+  end
 
-	def key_mode=(value)
-		@property_flush[:key_mode] = value
-	end
+  def cert_mode=(value)
+    @property_flush[:cert_mode] = value
+  end
 
-	def ca_chain=(value)
-	end
+  def key_file=(value)
+    @property_flush[:key_file] = value
+  end
 
-	def cert=(value)
-	end
+  def key_owner=(value)
+    @property_flush[:key_owner] = value
+  end
 
-	def key=(value)
-	end
+  def key_group=(value)
+    @property_flush[:key_group] = value
+  end
 
-	def flush_file_attributes(file, owner, group, mode, force=false)
-		# Update the file ownership if not in sync
-		if force || (@property_flush.include?(owner) && @property_hash[owner] != @property_flush[owner]) || (@property_flush.include?(group) && @property_hash[group] != @property_flush[group])
-			self.class.chown_file(file, @property_flush[owner], @property_flush[group])
-			@property_hash[owner] = @property_flush[owner]
-			@property_hash[group] = @property_flush[group]
-		end
+  def key_mode=(value)
+    @property_flush[:key_mode] = value
+  end
 
-		# Update the file permissions if not in sync
-		if force || (@property_flush.include?(mode) && @property_hash[mode] != @property_flush[mode])
-			self.class.chmod_file(file, @property_flush[mode])
-			@property_hash[mode] = @property_flush[mode]
-		end
-	end
+  def ca_chain=(value); end
 
-	def flush_file(file, content, owner, group, mode)
-		# If the file will be created (new, or moved), we must reset the attributes,
-		# since Puppet may not have signalled a change by calling the setter methods
-		force_reset_attributes = ! @property_hash.include?(content) || (@property_hash[content].nil? || @property_hash[content].empty?)
+  def cert=(value); end
 
-		# If the file path is being changed, delete the old file first and force all attributes
-		# to be reset, since they won't be correct on the new file, even if they were
-		# correct on the old file before
-		if @property_flush.include?(file) && @property_hash[file] != @property_flush[file]
-			self.class.delete_if_exists(@property_hash[file])
-			force_reset_attributes = true
+  def key=(value); end
 
-			# Indicate that we did change the file path
-			@property_hash[file] = @property_flush[file]
-		end
+  def flush_file_attributes(file, owner, group, mode, force = false)
+    # Update the file ownership if not in sync
+    if force || (@property_flush.include?(owner) && @property_hash[owner] != @property_flush[owner]) || (@property_flush.include?(group) && @property_hash[group] != @property_flush[group])
+      self.class.chown_file(file, @property_flush[owner], @property_flush[group])
+      @property_hash[owner] = @property_flush[owner]
+      @property_hash[group] = @property_flush[group]
+    end
 
-		if force_reset_attributes
-			@property_flush[owner] = @resource[owner]
-			@property_flush[group] = @resource[group]
-			@property_flush[mode] = @resource[mode]
-		end
+    # Update the file permissions if not in sync
+    # rubocop:disable Style/GuardClause
+    if force || (@property_flush.include?(mode) && @property_hash[mode] != @property_flush[mode])
+      self.class.chmod_file(file, @property_flush[mode])
+      @property_hash[mode] = @property_flush[mode]
+    end
+    # rubocop:enable Style/GuardClause
+  end
 
-		# Update the file content if not in sync
-		if force_reset_attributes || (@property_flush.include?(content) && @property_hash[content] != @property_flush[content])
-			File.write(@resource[file], @property_flush[content])
-			@property_hash[content] = @property_flush[content]
-		end
+  def flush_file(file, content, owner, group, mode)
+    # If the file will be created (new, or moved), we must reset the attributes,
+    # since Puppet may not have signalled a change by calling the setter methods
+    force_reset_attributes = !@property_hash.include?(content) || (@property_hash[content].nil? || @property_hash[content].empty?)
 
-		flush_file_attributes(@property_hash[file], owner, group, mode, force_reset_attributes)
-	end
+    # If the file path is being changed, delete the old file first and force all attributes
+    # to be reset, since they won't be correct on the new file, even if they were
+    # correct on the old file before
+    if @property_flush.include?(file) && @property_hash[file] != @property_flush[file]
+      self.class.delete_if_exists(@property_hash[file])
+      force_reset_attributes = true
 
-	def flush
-		info_file = "#{@cert_dir}/#{@resource[:name]}.json"
+      # Indicate that we did change the file path
+      @property_hash[file] = @property_flush[file]
+    end
 
-		if @property_flush[:ensure] == :absent
-			self.class.delete_if_exists(@resource[:ca_chain_file])
-			self.class.delete_if_exists(@resource[:cert_file])
-			self.class.delete_if_exists(@resource[:key_file])
-			self.class.delete_if_exists(info_file)
-			return
-		end
+    if force_reset_attributes
+      @property_flush[owner] = @resource[owner]
+      @property_flush[group] = @resource[group]
+      @property_flush[mode] = @resource[mode]
+    end
 
-		if needs_issue?
-			response = issue_cert
+    # Update the file content if not in sync
+    if force_reset_attributes || (@property_flush.include?(content) && @property_hash[content] != @property_flush[content])
+      File.write(@resource[file], @property_flush[content])
+      @property_hash[content] = @property_flush[content]
+    end
 
-			info = JSON.generate({
-				:data		   => response,
-				:cert_data         => @resource[:cert_data],
-				:ca_chain_file	   => @resource[:ca_chain_file],
-				:cert_file 	   => @resource[:cert_file],
-				:key_file	   => @resource[:key_file],
-			})
-			File.write(info_file, info)
-			flush_file_attributes(info_file, :info_owner, :info_group, :info_mode, true)
+    flush_file_attributes(@property_hash[file], owner, group, mode, force_reset_attributes)
+  end
 
-			# These are read-only properties which will never
-			# be set in the puppet resource, but we will set once
-			# a cert has been issued.
-			# These will be flushed to disk later if the is (@property_hash)
-			# does not match the should (@resource)
-			@property_flush[:ca_chain] = response['ca_chain'].join("\n")
-			@property_flush[:cert] = [response['certificate'], response['issuing_ca']].join("\n")
-			@property_flush[:key] = response['private_key']
-		else
-			flush_file_attributes(info_file, :info_owner, :info_group, :info_mode)
+  def flush
+    info_file = "#{@cert_dir}/#{@resource[:name]}.json"
 
-			# Re-read the info file to make sure the intended contents of the chain/cert/key files
-			# are correct
-			cert_info = JSON.parse(File.read(info_file))
-			@property_flush[:ca_chain] = cert_info['data']['ca_chain'].join("\n")
-			@property_flush[:cert] = [cert_info['data']['certificate'], cert_info['data']['issuing_ca']].join("\n")
-			@property_flush[:key] = cert_info['data']['private_key']
-		end
+    if @property_flush[:ensure] == :absent
+      self.class.delete_if_exists(@resource[:ca_chain_file])
+      self.class.delete_if_exists(@resource[:cert_file])
+      self.class.delete_if_exists(@resource[:key_file])
+      self.class.delete_if_exists(info_file)
+      return
+    end
 
-		flush_file(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
-		flush_file(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
-		flush_file(:key_file, :key, :key_owner, :key_group, :key_mode)
-	end
+    if needs_issue?
+      response = issue_cert
 
+      info = JSON.generate({
+                             data: response,
+        cert_data: @resource[:cert_data],
+        ca_chain_file: @resource[:ca_chain_file],
+        cert_file: @resource[:cert_file],
+        key_file: @resource[:key_file],
+                           })
+      File.write(info_file, info)
+      flush_file_attributes(info_file, :info_owner, :info_group, :info_mode, true)
+
+      # These are read-only properties which will never
+      # be set in the puppet resource, but we will set once
+      # a cert has been issued.
+      # These will be flushed to disk later if the is (@property_hash)
+      # does not match the should (@resource)
+      @property_flush[:ca_chain] = response['ca_chain'].join("\n")
+      @property_flush[:cert] = [response['certificate'], response['issuing_ca']].join("\n")
+      @property_flush[:key] = response['private_key']
+    else
+      flush_file_attributes(info_file, :info_owner, :info_group, :info_mode)
+
+      # Re-read the info file to make sure the intended contents of the chain/cert/key files
+      # are correct
+      cert_info = JSON.parse(File.read(info_file))
+      @property_flush[:ca_chain] = cert_info['data']['ca_chain'].join("\n")
+      @property_flush[:cert] = [cert_info['data']['certificate'], cert_info['data']['issuing_ca']].join("\n")
+      @property_flush[:key] = cert_info['data']['private_key']
+    end
+
+    flush_file(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
+    flush_file(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
+    flush_file(:key_file, :key, :key_owner, :key_group, :key_mode)
+  end
 end

--- a/lib/puppet/provider/vault_cert/ruby.rb
+++ b/lib/puppet/provider/vault_cert/ruby.rb
@@ -303,6 +303,7 @@ Puppet::Type.type(:vault_cert).provide(:ruby) do
         key_file: @resource[:key_file],
                            })
       File.write(info_file, info)
+      @property_flush[:info_mode] = @resource[:info_mode]
       flush_file_attributes(info_file, :info_owner, :info_group, :info_mode, true)
 
       # These are read-only properties which will never

--- a/lib/puppet/provider/vault_cert/ruby.rb
+++ b/lib/puppet/provider/vault_cert/ruby.rb
@@ -1,0 +1,327 @@
+require 'etc'
+require 'json'
+
+require "#{File.dirname(__FILE__)}/../../shared/vault_common.rb"
+
+Puppet::Type.type(:vault_cert).provide(:ruby) do
+	desc 'Issue certificates from Hashicorp Vault'
+
+	mk_resource_methods
+
+	def initialize(value={})
+		super(value)
+		@cert_dir = Facter.value(:vault_cert_dir)
+		@property_flush = {}
+	end
+
+	def self.instances
+		instances = []
+		cert_dir = Facter.value(:vault_cert_dir)
+		cert_filenames = Dir.glob("#{cert_dir}/*.json")
+		cert_filenames.each do |info_file|
+			name = File.basename(info_file, '.json')
+			
+			info_content, info_owner, info_group, info_mode = load_file(info_file)
+			cert_info = JSON.parse(info_content)
+
+			next unless ['data', 'cert_data', 'ca_chain_file', 'cert_file', 'key_file'].all? {|k| cert_info.key? k}
+
+			ca_chain, ca_chain_owner, ca_chain_group, ca_chain_mode = load_file(cert_info['ca_chain_file'])
+			cert, cert_owner, cert_group, cert_mode = load_file(cert_info['cert_file'])
+			key, key_owner, key_group, key_mode = load_file(cert_info['key_file'])
+
+			begin
+				expiration = cert_info['data']['expiration']
+			rescue
+				expiration = nil
+			end
+
+			instances << new(
+				ensure: :present,
+				name: name,
+				cert_data: cert_info['cert_data'],
+				expiration: expiration,
+				# Info file
+				info_owner: info_owner,
+				info_group: info_group,
+				info_mode: info_mode,
+				# CA Chain
+				ca_chain_file: cert_info['ca_chain_file'],
+				ca_chain_owner: ca_chain_owner,
+				ca_chain_group: ca_chain_group,
+				ca_chain_mode: ca_chain_mode,
+				ca_chain: ca_chain,
+				info_ca_chain: cert_info['data']['ca_chain'].join("\n"),
+				# Certificate
+				cert_file: cert_info['cert_file'],
+				cert_owner: cert_owner,
+				cert_group: cert_group,
+				cert_mode: cert_mode,
+				cert: cert,
+				info_cert: [cert_info['data']['certificate'], cert_info['data']['issuing_ca']].join("\n"),
+				# Private Key
+				key_file: cert_info['key_file'],
+				key_owner: key_owner,
+				key_group: key_group,
+				key_mode: key_mode,
+				key: key,
+				info_key: cert_info['data']['private_key']
+			)
+		end
+		return instances
+	end
+
+	def self.prefetch(resources)
+		instances.each do |prov|
+			if (resource = resources[prov.name])
+			resource.provider = prov
+			end
+		end
+	end
+
+	def exists?
+		Puppet.info("property_hash includes ensure? #{@property_hash.include?(:ensure)}")
+		@property_hash[:ensure] == :present
+	end
+
+	def create
+		@property_flush[:ensure] = :present
+	end
+
+	def destroy
+		@property_flush[:ensure] = :absent
+	end
+
+	def issue_cert
+		Puppet.info("Requesting certificate #{@resource[:name]}")
+
+		uri = URI(@resource[:vault_uri])
+		raise Puppet::Error, "Unable to parse a hostname from #{@resource[:vault_uri]}" unless uri.hostname
+
+		# Try known paths for trusted CA certificate bundles
+		ca_trust = if File.exist?('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')
+				'/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+			   elsif File.exist?('/etc/ssl/certs/ca-certificates.crt')
+				'/etc/ssl/certs/ca-certificates.crt'
+			   else
+				nil
+			   end
+		raise Puppet::Error, 'Failed to get the trusted CA certificate file' if ca_trust.nil?
+
+		http = http_create_secure(uri, ca_trust, @resource[:timeout])
+		token = vault_get_token(http, @resource[:auth_path].delete('/'))
+		secrets = vault_http_post(http, uri.path, token, @resource[:cert_data])
+		response = vault_parse_data(secrets)
+
+		return response
+	end
+
+	def self.load_file(file)
+		if file && File.exists?(file)
+			content = File.read(file)
+			stat = File::Stat.new(file)
+			owner = Etc.getpwuid(stat.uid).name
+			group = Etc.getgrgid(stat.gid).name
+			mode = sprintf("%04o", stat.mode & 07777)
+			return content, owner, group, mode
+		else
+			return nil, nil, nil, nil
+		end
+	end
+
+	def chown_file(file, owner, group)
+		uid = owner ? Etc.getpwnam(owner).uid : nil
+		gid = group ? Etc.getgrnam(group).gid : nil
+		Puppet.info("Chowning #{file} to #{uid}:#{gid}")
+		File.chown(uid, gid, file)
+	end
+
+	def chmod_file(file, mode)
+		File.chmod(mode.to_i(8), file) if mode
+	end
+
+	def delete_if_exists(file)
+		File.delete(file) if ! file.to_s.empty? && File.exist?(file)
+	end
+
+	def expires_soon_or_expired
+		time_now = Time.now.to_i
+		renewal_time = @property_hash[:expiration] - (@resource[:renewal_threshold] * 3600 * 24)
+		return time_now >= renewal_time
+	end
+
+	def needs_issue?
+		return true if @property_hash[:ensure] != :present
+		return true if @property_hash[:cert_data] != @property_flush[:cert_data]
+		return true if expires_soon_or_expired
+	end
+
+	def info_owner=(value)
+		@property_flush[:info_owner] = value
+	end
+
+	def info_group=(value)
+		@property_flush[:info_group] = value
+	end
+
+	def info_mode=(value)
+		@property_flush[:info_mode] = value
+	end
+
+	def cert_data=(value)
+		@property_flush[:cert_data] = value
+	end
+
+	def ca_chain_file=(value)
+		@property_flush[:ca_chain_file] = value
+	end
+
+	def ca_chain_owner=(value)
+		@property_flush[:ca_chain_owner] = value
+	end
+ 
+	def ca_chain_group=(value)
+		@property_flush[:ca_chain_group] = value
+	end
+
+	def ca_chain_mode=(value)
+		@property_flush[:ca_chain_mode] = value
+	end
+
+	def cert_file=(value)
+		@property_flush[:cert_file] = value
+	end
+
+	def cert_owner=(value)
+		@property_flush[:cert_owner] = value
+	end
+ 
+	def cert_group=(value)
+		@property_flush[:cert_group] = value
+	end
+
+	def cert_mode=(value)
+		@property_flush[:cert_mode] = value
+	end
+
+	def key_file=(value)
+		@property_flush[:key_file] = value
+	end
+
+	def key_owner=(value)
+		@property_flush[:key_owner] = value
+	end
+ 
+	def key_group=(value)
+		@property_flush[:key_group] = value
+	end
+
+	def key_mode=(value)
+		@property_flush[:key_mode] = value
+	end
+
+	def ca_chain=(value)
+	end
+
+	def cert=(value)
+	end
+
+	def key=(value)
+	end
+
+	def flush_file_attributes(file, owner, group, mode, force)
+		# Update the file ownership if not in sync
+		if force || (@property_flush.include?(owner) && @property_hash[owner] != @property_flush[owner]) || (@property_flush.include?(group) && @property_hash[group] != @property_flush[group])
+			self.class.chown_file(file, @property_flush[owner], @property_flush[group])
+			@property_hash[owner] = @property_flush[owner]
+			@property_hash[group] = @property_flush[group]
+		end
+
+		# Update the file permissions if not in sync
+		if force || (@property_flush.include?(mode) && @property_hash[mode] != @property_flush[mode])
+			self.class.chmod_file(file, @property_flush[mode])
+			@property_hash[mode] = @property_flush[mode]
+		end
+	end
+
+	def flush_file(file, content, owner, group, mode)
+		# If the file will be created (new, or moved), we must reset the attributes,
+		# since Puppet may not have signalled a change by calling the setter methods
+		force_reset_attributes = @property_hash.include?(content) || @property_hash[content].nil? || @property_hash[content].blank?
+
+		# If the file path is being changed, delete the old file first and force all attributes
+		# to be reset, since they won't be correct on the new file, even if they were
+		# correct on the old file before
+		if @property_flush.include?(file) && @property_hash[file] != @property_flush[file]
+			self.class.delete_if_exists(@property_hash[file])
+			force_reset_attributes = true
+
+			# Indicate that we did change the file path
+			@property_hash[file] = @property_flush[file]
+		end
+
+		if force_reset_attributes
+			@property_flush[owner] = @resource[owner]
+			@property_flush[group] = @resource[group]
+			@property_flush[mode] = @resource[mode]
+		end
+
+		# Update the file content if not in sync
+		if force_reset_attributes || (@property_flush.include?(content) && @property_hash[content] != @property_flush[content])
+			File.write(@resource[file], @property_flush[content])
+			@property_hash[content] = @property_flush[content]
+		end
+
+		flush_file_attributes(@property_hash[file], owner, group, mode, force_reset_attributes)
+	end
+
+	def flush
+		info_file = "#{@cert_dir}/#{@resource[:name]}.json"
+
+		if @property_flush[:ensure] == :absent
+			self.class.delete_if_exists(@resource[:ca_chain_file])
+			self.class.delete_if_exists(@resource[:cert_file])
+			self.class.delete_if_exists(@resource[:key_file])
+			self.class.delete_if_exists(info_file)
+			return
+		end
+
+		if needs_issue?
+			response = issue_cert
+
+			info = JSON.generate({
+				:data		   => response,
+				:cert_data         => @resource[:cert_data],
+				:ca_chain_file	   => @resource[:ca_chain_file],
+				:cert_file 	   => @resource[:cert_file],
+				:key_file	   => @resource[:key_file],
+			})
+			File.write(info_file, info)
+			flush_file_attributes(info_file, :info_owner, :info_group, :info_mode, true)
+
+			# These are read-only properties which will never
+			# be set in the puppet resource, but we will set once
+			# a cert has been issued.
+			# These will be flushed to disk later if the is (@property_hash)
+			# does not match the should (@resource)
+			@property_flush[:ca_chain] = response['ca_chain'].join("\n")
+			@property_flush[:cert] = [response['certificate'], response['issuing_ca']].join("\n")
+			@property_flush[:key] = response['private_key']
+		else
+			flush_file_attributes(info_file, :info_owner, :info_group, :info_mode)
+
+			# Re-read the info file to make sure the intended contents of the chain/cert/key files
+			# are correct
+			cert_info = JSON.parse(File.read(info_file))
+			@property_flush[:ca_chain] = cert_info['data']['ca_chain'].join("\n")
+			@property_flush[:cert] = [cert_info['data']['certificate'], cert_info['data']['issuing_ca']].join("\n")
+			@property_flush[:key] = cert_info['data']['private_key']
+		end
+
+		flush_file(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
+		flush_file(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
+		flush_file(:key_file, :key, :key_owner, :key_group, :key_mode)
+
+	end
+
+end

--- a/lib/puppet/provider/vault_cert/ruby.rb
+++ b/lib/puppet/provider/vault_cert/ruby.rb
@@ -275,7 +275,7 @@ Puppet::Type.type(:vault_cert).provide(:ruby) do
       @property_hash[content] = @property_flush[content]
     end
 
-    flush_file_attributes(@property_hash[file], owner, group, mode, force_reset_attributes)
+    flush_file_attributes(@resource[file], owner, group, mode, force_reset_attributes)
   end
 
   def flush

--- a/lib/puppet/provider/vault_cert/ruby.rb
+++ b/lib/puppet/provider/vault_cert/ruby.rb
@@ -286,6 +286,9 @@ Puppet::Type.type(:vault_cert).provide(:ruby) do
       self.class.delete_if_exists(@resource[:cert_file])
       self.class.delete_if_exists(@resource[:key_file])
       self.class.delete_if_exists(info_file)
+      # Remove all other attributes so that `puppet resource`
+      # shows the correct state after removal
+      @property_hash = @property_hash.slice(:ensure)
       return
     end
 

--- a/lib/puppet/provider/vault_cert/vault_cert.rb
+++ b/lib/puppet/provider/vault_cert/vault_cert.rb
@@ -3,7 +3,7 @@ require 'json'
 
 require "#{File.dirname(__FILE__)}/../../shared/vault_common.rb"
 
-Puppet::Type.type(:vault_cert).provide(:ruby) do
+Puppet::Type.type(:vault_cert).provide(:vault_cert) do
   desc 'Issue certificates from Hashicorp Vault'
 
   mk_resource_methods

--- a/lib/puppet/type/vault_cert.rb
+++ b/lib/puppet/type/vault_cert.rb
@@ -54,8 +54,8 @@ Puppet::Type.newtype(:vault_cert) do
     newproperty(:ca_chain_file) do
         desc 'Where the CA chain file should be written'
         defaultto do
-                cert_dir = Facter.value(:vault_cert_dir)
-                      "#{cert_dir}/#{@resource[:name]}.chain.crt"
+            cert_dir = Facter.value(:vault_cert_dir)
+            "#{cert_dir}/#{@resource[:name]}.chain.crt"
         end
     end
 
@@ -74,7 +74,7 @@ Puppet::Type.newtype(:vault_cert) do
         defaultto '0644'
     end
 
-    newproperty(:ca_chain, :readonly => true) do
+    newproperty(:ca_chain) do
         desc 'Read-only property which contains the value of the CA chain'
         newvalues(:auto)
         defaultto :auto
@@ -84,7 +84,7 @@ Puppet::Type.newtype(:vault_cert) do
         end
     end
 
-    newproperty(:info_ca_chain, :readonly => true) do
+    newproperty(:info_ca_chain) do
         desc 'Read-only property which contains the value of the CA chain from the info file'
         newvalues(:auto)
         defaultto :auto
@@ -119,7 +119,7 @@ Puppet::Type.newtype(:vault_cert) do
         defaultto '0644'
     end
 
-    newproperty(:cert, :readonly => true) do
+    newproperty(:cert) do
         desc 'Read-only property which contains the value of the certificate'
         newvalues(:auto)
         defaultto :auto
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:vault_cert) do
         end
     end
 
-    newproperty(:info_cert, :readonly => true) do
+    newproperty(:info_cert) do
         desc 'Read-only property which contains the value of the cerificate from the info file'
         newvalues(:auto)
         defaultto :auto
@@ -165,7 +165,7 @@ Puppet::Type.newtype(:vault_cert) do
         defaultto '0600'
     end
 
-    newproperty(:info_key, :readonly => true) do
+    newproperty(:info_key) do
         desc 'Read-only property which contains the value of the private key from the info file'
         newvalues(:auto)
         defaultto :auto
@@ -176,7 +176,7 @@ Puppet::Type.newtype(:vault_cert) do
         end
     end
 
-    newproperty(:key, :readonly => true) do
+    newproperty(:key) do
         desc 'Read-only property which contains the value of the privat ekey'
         newvalues(:auto)
         defaultto :auto
@@ -187,21 +187,13 @@ Puppet::Type.newtype(:vault_cert) do
         end
     end
 
-    newproperty(:expiration, :readonly => true) do
+    newproperty(:expiration) do
         desc 'Read-only property showing the expiration time of the certificate'
         newvalues(:auto)
         defaultto :auto
 
         def insync?(is)
             ! provider.expires_soon_or_expired
-        end
-    end
-
-    READ_ONLY_PROPERTIES = [:ca_chain, :info_ca_chain, :cert, :info_cert, :key, :info_key, :expiration].freeze
-
-    validate do
-        READ_ONLY_PROPERTIES.each do |property|
-            self.fail _("Property '%{property}' is read-only") % { property: property } if self[property] != :auto
         end
     end
 

--- a/lib/puppet/type/vault_cert.rb
+++ b/lib/puppet/type/vault_cert.rb
@@ -1,0 +1,208 @@
+Puppet::Type.newtype(:vault_cert) do
+    @doc = 'A type representing a certificate issued by Hashicorp Vault'
+    ensurable
+
+    newparam(:name) do
+        isnamevar
+        desc 'The name of the certificate'
+    end
+
+    newparam(:vault_uri) do
+        desc 'The full URI of the vault PKI secrets engine'
+        isrequired
+    end
+
+    newparam(:auth_path) do
+        desc 'The path used to authenticate puppet agent to vault'
+        defaultto 'puppet-pki'
+    end
+
+    newparam(:timeout) do
+        desc 'Length of time to wait on vault connections'
+        defaultto 5
+    end
+
+    newparam(:renewal_threshold) do
+        desc 'Certificate should be renewed when fewer than this many days remain before expiry'
+        defaultto 3
+    end
+
+    newproperty(:cert_data) do
+        desc 'The attributes of the certificate to be issued'
+        isrequired
+    end
+
+    # Info file
+    
+    newproperty(:info_owner) do
+        desc 'The user which the info_file should be owned by'
+        defaultto 'root'
+    end
+
+    newproperty(:info_group) do
+        desc 'The group which the info_file should be owned by'
+        defaultto 'root'
+    end
+
+    newproperty(:info_mode) do
+        desc 'The file mode the info_file should be written with'
+        defaultto '0600'
+    end
+
+    # CA Chain
+
+    newproperty(:ca_chain_file) do
+        desc 'Where the CA chain file should be written'
+        defaultto do
+                cert_dir = Facter.value(:vault_cert_dir)
+                      "#{cert_dir}/#{@resource[:name]}.chain.crt"
+        end
+    end
+
+    newproperty(:ca_chain_owner) do
+        desc 'The user which the ca_chain_file should be owned by'
+        defaultto 'root'
+    end
+
+    newproperty(:ca_chain_group) do
+        desc 'The group which the ca_chain_file should be owned by'
+        defaultto 'root'
+    end
+
+    newproperty(:ca_chain_mode) do
+        desc 'The file mode the ca_chain_file should be written with'
+        defaultto '0644'
+    end
+
+    newproperty(:ca_chain, :readonly => true) do
+        desc 'Read-only property which contains the value of the CA chain'
+        newvalues(:auto)
+        defaultto :auto
+
+        def insync?(is)
+            is == resource.property(:info_ca_chain).retrieve
+        end
+    end
+
+    newproperty(:info_ca_chain, :readonly => true) do
+        desc 'Read-only property which contains the value of the CA chain from the info file'
+        newvalues(:auto)
+        defaultto :auto
+
+        def insync?(is)
+            true
+        end
+    end
+
+    # Certificate
+
+    newproperty(:cert_file) do
+        desc 'Where the certificate file should be written'
+        defaultto do
+                cert_dir = Facter.value(:vault_cert_dir)
+                      "#{cert_dir}/#{@resource[:name]}.crt"
+        end
+    end
+
+    newproperty(:cert_owner) do
+        desc 'The user which the cert_file should be owned by'
+        defaultto 'root'
+    end
+
+    newproperty(:cert_group) do
+        desc 'The group which the cert_file should be owned by'
+        defaultto 'root'
+    end
+
+    newproperty(:cert_mode) do
+        desc 'The file mode the cert _file should be written with'
+        defaultto '0644'
+    end
+
+    newproperty(:cert, :readonly => true) do
+        desc 'Read-only property which contains the value of the certificate'
+        newvalues(:auto)
+        defaultto :auto
+
+        def insync?(is)
+            is == resource.property(:info_cert).retrieve
+        end
+    end
+
+    newproperty(:info_cert, :readonly => true) do
+        desc 'Read-only property which contains the value of the cerificate from the info file'
+        newvalues(:auto)
+        defaultto :auto
+
+        def insync?(is)
+            true
+        end
+    end
+
+
+    # Private Key
+
+    newproperty(:key_file) do
+        desc 'Where the key file should be written'
+        defaultto do
+            cert_dir = Facter.value(:vault_cert_dir)
+            "#{cert_dir}/#{@resource[:name]}.key"
+        end
+    end
+
+    newproperty(:key_owner) do
+        desc 'The user which the key_file should be owned by'
+        defaultto 'root'
+    end
+
+    newproperty(:key_group) do
+        desc 'The group which the key_file should be owned by'
+        defaultto 'root'
+    end
+
+    newproperty(:key_mode) do
+        desc 'The file mode the key file should be written with'
+        defaultto '0600'
+    end
+
+    newproperty(:info_key, :readonly => true) do
+        desc 'Read-only property which contains the value of the private key from the info file'
+        newvalues(:auto)
+        defaultto :auto
+        #sensitive true
+
+        def insync?(is)
+            true
+        end
+    end
+
+    newproperty(:key, :readonly => true) do
+        desc 'Read-only property which contains the value of the privat ekey'
+        newvalues(:auto)
+        defaultto :auto
+        sensitive true
+
+        def insync?(is)
+            is == resource.property(:info_key).retrieve
+        end
+    end
+
+    newproperty(:expiration, :readonly => true) do
+        desc 'Read-only property showing the expiration time of the certificate'
+        newvalues(:auto)
+        defaultto :auto
+
+        def insync?(is)
+            ! provider.expires_soon_or_expired
+        end
+    end
+
+    READ_ONLY_PROPERTIES = [:ca_chain, :info_ca_chain, :cert, :info_cert, :key, :info_key, :expiration].freeze
+
+    validate do
+        READ_ONLY_PROPERTIES.each do |property|
+            self.fail _("Property '%{property}' is read-only") % { property: property } if self[property] != :auto
+        end
+    end
+
+end

--- a/lib/puppet/type/vault_cert.rb
+++ b/lib/puppet/type/vault_cert.rb
@@ -1,200 +1,198 @@
 Puppet::Type.newtype(:vault_cert) do
-    @doc = 'A type representing a certificate issued by Hashicorp Vault'
-    ensurable
+  @doc = 'A type representing a certificate issued by Hashicorp Vault'
+  ensurable
 
-    newparam(:name) do
-        isnamevar
-        desc 'The name of the certificate'
+  newparam(:name) do
+    isnamevar
+    desc 'The name of the certificate'
+  end
+
+  newparam(:vault_uri) do
+    desc 'The full URI of the vault PKI secrets engine'
+    isrequired
+  end
+
+  newparam(:auth_path) do
+    desc 'The path used to authenticate puppet agent to vault'
+    defaultto 'puppet-pki'
+  end
+
+  newparam(:timeout) do
+    desc 'Length of time to wait on vault connections'
+    defaultto 5
+  end
+
+  newparam(:renewal_threshold) do
+    desc 'Certificate should be renewed when fewer than this many days remain before expiry'
+    defaultto 3
+  end
+
+  newproperty(:cert_data) do
+    desc 'The attributes of the certificate to be issued'
+    isrequired
+  end
+
+  # Info file
+
+  newproperty(:info_owner) do
+    desc 'The user which the info_file should be owned by'
+    defaultto 'root'
+  end
+
+  newproperty(:info_group) do
+    desc 'The group which the info_file should be owned by'
+    defaultto 'root'
+  end
+
+  newproperty(:info_mode) do
+    desc 'The file mode the info_file should be written with'
+    defaultto '0600'
+  end
+
+  # CA Chain
+
+  newproperty(:ca_chain_file) do
+    desc 'Where the CA chain file should be written'
+    defaultto do
+      cert_dir = Facter.value(:vault_cert_dir)
+      "#{cert_dir}/#{@resource[:name]}.chain.crt"
     end
+  end
 
-    newparam(:vault_uri) do
-        desc 'The full URI of the vault PKI secrets engine'
-        isrequired
+  newproperty(:ca_chain_owner) do
+    desc 'The user which the ca_chain_file should be owned by'
+    defaultto 'root'
+  end
+
+  newproperty(:ca_chain_group) do
+    desc 'The group which the ca_chain_file should be owned by'
+    defaultto 'root'
+  end
+
+  newproperty(:ca_chain_mode) do
+    desc 'The file mode the ca_chain_file should be written with'
+    defaultto '0644'
+  end
+
+  newproperty(:ca_chain) do
+    desc 'Read-only property which contains the value of the CA chain'
+    newvalues(:auto)
+    defaultto :auto
+
+    def insync?(is)
+      is == resource.property(:info_ca_chain).retrieve
     end
+  end
 
-    newparam(:auth_path) do
-        desc 'The path used to authenticate puppet agent to vault'
-        defaultto 'puppet-pki'
+  newproperty(:info_ca_chain) do
+    desc 'Read-only property which contains the value of the CA chain from the info file'
+    newvalues(:auto)
+    defaultto :auto
+
+    def insync?(_is)
+      true
     end
+  end
 
-    newparam(:timeout) do
-        desc 'Length of time to wait on vault connections'
-        defaultto 5
+  # Certificate
+
+  newproperty(:cert_file) do
+    desc 'Where the certificate file should be written'
+    defaultto do
+      cert_dir = Facter.value(:vault_cert_dir)
+      "#{cert_dir}/#{@resource[:name]}.crt"
     end
+  end
 
-    newparam(:renewal_threshold) do
-        desc 'Certificate should be renewed when fewer than this many days remain before expiry'
-        defaultto 3
+  newproperty(:cert_owner) do
+    desc 'The user which the cert_file should be owned by'
+    defaultto 'root'
+  end
+
+  newproperty(:cert_group) do
+    desc 'The group which the cert_file should be owned by'
+    defaultto 'root'
+  end
+
+  newproperty(:cert_mode) do
+    desc 'The file mode the cert _file should be written with'
+    defaultto '0644'
+  end
+
+  newproperty(:cert) do
+    desc 'Read-only property which contains the value of the certificate'
+    newvalues(:auto)
+    defaultto :auto
+
+    def insync?(is)
+      is == resource.property(:info_cert).retrieve
     end
+  end
 
-    newproperty(:cert_data) do
-        desc 'The attributes of the certificate to be issued'
-        isrequired
+  newproperty(:info_cert) do
+    desc 'Read-only property which contains the value of the cerificate from the info file'
+    newvalues(:auto)
+    defaultto :auto
+
+    def insync?(_is)
+      true
     end
+  end
 
-    # Info file
-    
-    newproperty(:info_owner) do
-        desc 'The user which the info_file should be owned by'
-        defaultto 'root'
+  # Private Key
+
+  newproperty(:key_file) do
+    desc 'Where the key file should be written'
+    defaultto do
+      cert_dir = Facter.value(:vault_cert_dir)
+      "#{cert_dir}/#{@resource[:name]}.key"
     end
+  end
 
-    newproperty(:info_group) do
-        desc 'The group which the info_file should be owned by'
-        defaultto 'root'
+  newproperty(:key_owner) do
+    desc 'The user which the key_file should be owned by'
+    defaultto 'root'
+  end
+
+  newproperty(:key_group) do
+    desc 'The group which the key_file should be owned by'
+    defaultto 'root'
+  end
+
+  newproperty(:key_mode) do
+    desc 'The file mode the key file should be written with'
+    defaultto '0600'
+  end
+
+  newproperty(:info_key) do
+    desc 'Read-only property which contains the value of the private key from the info file'
+    newvalues(:auto)
+    defaultto :auto
+    # sensitive true
+
+    def insync?(_is)
+      true
     end
+  end
 
-    newproperty(:info_mode) do
-        desc 'The file mode the info_file should be written with'
-        defaultto '0600'
+  newproperty(:key) do
+    desc 'Read-only property which contains the value of the privat ekey'
+    newvalues(:auto)
+    defaultto :auto
+    sensitive true
+
+    def insync?(is)
+      is == resource.property(:info_key).retrieve
     end
+  end
 
-    # CA Chain
+  newproperty(:expiration) do
+    desc 'Read-only property showing the expiration time of the certificate'
+    newvalues(:auto)
+    defaultto :auto
 
-    newproperty(:ca_chain_file) do
-        desc 'Where the CA chain file should be written'
-        defaultto do
-            cert_dir = Facter.value(:vault_cert_dir)
-            "#{cert_dir}/#{@resource[:name]}.chain.crt"
-        end
+    def insync?(_is)
+      !provider.expires_soon_or_expired
     end
-
-    newproperty(:ca_chain_owner) do
-        desc 'The user which the ca_chain_file should be owned by'
-        defaultto 'root'
-    end
-
-    newproperty(:ca_chain_group) do
-        desc 'The group which the ca_chain_file should be owned by'
-        defaultto 'root'
-    end
-
-    newproperty(:ca_chain_mode) do
-        desc 'The file mode the ca_chain_file should be written with'
-        defaultto '0644'
-    end
-
-    newproperty(:ca_chain) do
-        desc 'Read-only property which contains the value of the CA chain'
-        newvalues(:auto)
-        defaultto :auto
-
-        def insync?(is)
-            is == resource.property(:info_ca_chain).retrieve
-        end
-    end
-
-    newproperty(:info_ca_chain) do
-        desc 'Read-only property which contains the value of the CA chain from the info file'
-        newvalues(:auto)
-        defaultto :auto
-
-        def insync?(is)
-            true
-        end
-    end
-
-    # Certificate
-
-    newproperty(:cert_file) do
-        desc 'Where the certificate file should be written'
-        defaultto do
-                cert_dir = Facter.value(:vault_cert_dir)
-                      "#{cert_dir}/#{@resource[:name]}.crt"
-        end
-    end
-
-    newproperty(:cert_owner) do
-        desc 'The user which the cert_file should be owned by'
-        defaultto 'root'
-    end
-
-    newproperty(:cert_group) do
-        desc 'The group which the cert_file should be owned by'
-        defaultto 'root'
-    end
-
-    newproperty(:cert_mode) do
-        desc 'The file mode the cert _file should be written with'
-        defaultto '0644'
-    end
-
-    newproperty(:cert) do
-        desc 'Read-only property which contains the value of the certificate'
-        newvalues(:auto)
-        defaultto :auto
-
-        def insync?(is)
-            is == resource.property(:info_cert).retrieve
-        end
-    end
-
-    newproperty(:info_cert) do
-        desc 'Read-only property which contains the value of the cerificate from the info file'
-        newvalues(:auto)
-        defaultto :auto
-
-        def insync?(is)
-            true
-        end
-    end
-
-
-    # Private Key
-
-    newproperty(:key_file) do
-        desc 'Where the key file should be written'
-        defaultto do
-            cert_dir = Facter.value(:vault_cert_dir)
-            "#{cert_dir}/#{@resource[:name]}.key"
-        end
-    end
-
-    newproperty(:key_owner) do
-        desc 'The user which the key_file should be owned by'
-        defaultto 'root'
-    end
-
-    newproperty(:key_group) do
-        desc 'The group which the key_file should be owned by'
-        defaultto 'root'
-    end
-
-    newproperty(:key_mode) do
-        desc 'The file mode the key file should be written with'
-        defaultto '0600'
-    end
-
-    newproperty(:info_key) do
-        desc 'Read-only property which contains the value of the private key from the info file'
-        newvalues(:auto)
-        defaultto :auto
-        #sensitive true
-
-        def insync?(is)
-            true
-        end
-    end
-
-    newproperty(:key) do
-        desc 'Read-only property which contains the value of the privat ekey'
-        newvalues(:auto)
-        defaultto :auto
-        sensitive true
-
-        def insync?(is)
-            is == resource.property(:info_key).retrieve
-        end
-    end
-
-    newproperty(:expiration) do
-        desc 'Read-only property showing the expiration time of the certificate'
-        newvalues(:auto)
-        defaultto :auto
-
-        def insync?(is)
-            ! provider.expires_soon_or_expired
-        end
-    end
-
+  end
 end

--- a/lib/puppet/type/vault_cert.rb
+++ b/lib/puppet/type/vault_cert.rb
@@ -195,4 +195,29 @@ Puppet::Type.newtype(:vault_cert) do
       !provider.expires_soon_or_expired
     end
   end
+
+  autorequire(:file) do
+    [
+      Facter.value(:vault_cert_dir),
+      File.dirname(self[:ca_chain_file]),
+      File.dirname(self[:cert_file]),
+      File.dirname(self[:key_file]),
+    ].uniq
+  end
+
+  autorequire(:user) do
+    [
+      self[:ca_chain_owner],
+      self[:cert_owner],
+      self[:key_owner],
+    ].uniq
+  end
+
+  autorequire(:group) do
+    [
+      self[:ca_chain_group],
+      self[:cert_group],
+      self[:key_group],
+    ].uniq
+  end
 end

--- a/manifests/vault_cert.pp
+++ b/manifests/vault_cert.pp
@@ -1,0 +1,20 @@
+# @summary 
+class vault_secrets::vault_cert (
+  $purge=false
+) {
+
+  file {
+    $::vault_cert_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755'
+  }
+
+  if $purge {
+    resources {
+      'vault_cert':
+        purge => true;
+    }
+  }
+}

--- a/spec/unit/provider/ruby_spec.rb
+++ b/spec/unit/provider/ruby_spec.rb
@@ -5,16 +5,16 @@ type_class = Puppet::Type.type(:vault_cert)
 provider_class = type_class.provider(:ruby)
 
 describe provider_class do
-  let(:resource) {
-    Puppet::Type.type(:vault_cert).new({ name: 'test', :provider => described_class.name})
-  }
+  let(:resource) do
+    Puppet::Type.type(:vault_cert).new({ name: 'test', provider: described_class.name })
+  end
   let(:provider) { resource.provider }
 
   before :each do
     allow(Facter).to receive(:value).with(:vault_cert_dir).and_return('/test/vault-secrets')
   end
 
-  it 'should have the correct vault_cert_dir' do
+  it 'has the correct vault_cert_dir' do
     resource = described_class.new(name: 'test', ensure: :present, cert_data: {}, expiration: 123)
     expect(resource.instance_variable_get(:@cert_dir)).to eq '/test/vault-secrets'
   end
@@ -23,10 +23,16 @@ describe provider_class do
     before :each do
       info_files = {
         '/test/vault-secrets/test.json' => {
-          :contents => '{"data":{"expiration": 123, "ca_chain": ["testchain"], "issuing_ca": "testca", "certificate": "testcert", "private_key": "testkey"}, "cert_data": {}, "ca_chain_file": "/test/vault-secrets/test.chain.crt", "cert_file": "/test/vault-secrets/test.crt", "key_file": "/test/vault-secrets/test.key" }',
+          contents: '{"data":{"expiration": 123, "ca_chain": ["testchain"], '\
+                    '"issuing_ca": "testca", "certificate": "testcert", "private_key": "testkey"}, '\
+                    '"cert_data": {}, "ca_chain_file": "/test/vault-secrets/test.chain.crt", '\
+                    '"cert_file": "/test/vault-secrets/test.crt", "key_file": "/test/vault-secrets/test.key" }',
         },
         '/test/vault-secrets/test2.json' => {
-          :contents => '{"data":{"expiration": 123, "ca_chain": ["testchain2"], "issuing_ca": "testca2", "certificate": "testcert2", "private_key": "testkey2"}, "cert_data": {}, "ca_chain_file": "/test/vault-secrets/test2.chain.crt", "cert_file": "/test/vault-secrets/test2.crt", "key_file": "/test/vault-secrets/test2.key" }',
+          contents: '{"data":{"expiration": 123, "ca_chain": ["testchain2"], '\
+                    '"issuing_ca": "testca2", "certificate": "testcert2", "private_key": "testkey2"}, '\
+                    '"cert_data": {}, "ca_chain_file": "/test/vault-secrets/test2.chain.crt", '\
+                    '"cert_file": "/test/vault-secrets/test2.crt", "key_file": "/test/vault-secrets/test2.key" }',
         }
       }
 
@@ -42,7 +48,7 @@ describe provider_class do
 
     describe 'self.instances' do
       it 'returns an aray of certificate data' do
-        instances = provider_class.instances.collect { |x| x.name }
+        instances = provider_class.instances.map { |x| x.name }
         expect(instances).to contain_exactly('test', 'test2')
       end
     end
@@ -58,8 +64,8 @@ describe provider_class do
         test2 = provider_class.new(name: 'test2', ensure: :present)
         test4 = provider_class.new(name: 'test4', ensure: :present)
         allow(provider_class).to receive(:instances).and_return([
-          test1, test2, test4
-        ])
+                                                                  test1, test2, test4
+                                                                ])
         provider.class.prefetch(defined_resources)
         expect(defined_resources['test1'].provider).to be test1
         expect(defined_resources['test2'].provider).to be test2
@@ -67,39 +73,31 @@ describe provider_class do
       end
     end
   end
-    
+
   describe 'self.load_file' do
-    it 'should return nil when asked to load nil' do
-      allow(File).to receive(:exists?)
-      allow(File).to receive(:read)
-      allow(File).to receive(:stat)
+    it 'returns nil when asked to load nil' do
+      expect(File).not_to receive(:exist?)
+      expect(File).not_to receive(:read)
+      expect(File).not_to receive(:stat)
 
       expect(provider_class.load_file(nil)).to eq [nil, nil, nil, nil]
-
-      expect(File).not_to have_received(:exists?)
-      expect(File).not_to have_received(:read)
-      expect(File).not_to have_received(:stat)
     end
 
-    it 'should return nil when asked to load a non-existent file' do
-      allow(File).to receive(:exists?).and_return(false)
-      allow(File).to receive(:read)
-      allow(File).to receive(:stat)
+    it 'returns nil when asked to load a non-existent file' do
+      expect(File).to receive(:exist?).with('/test/vault-secrets/test.json').and_return(false)
+      expect(File).not_to receive(:read)
+      expect(File).not_to receive(:stat)
 
       expect(provider_class.load_file('/test/vault-secrets/test.json')).to eq [nil, nil, nil, nil]
-      
-      expect(File).to have_received(:exists?).with('/test/vault-secrets/test.json')
-      expect(File).not_to have_received(:read)
-      expect(File).not_to have_received(:stat)
     end
 
-    it 'should return file attributes when called for an existing file' do
+    it 'returns file attributes when called for an existing file' do
       file = '/test/vault-secrets/test.json'
-      allow(File).to receive(:exists?).with(file).and_return(true)
+      allow(File).to receive(:exist?).with(file).and_return(true)
       allow(File).to receive(:read).with(file).and_return('testcontent')
-      allow(File::Stat).to receive(:new).with(file).and_return(double('File::Stat', :uid => 123, :gid => 123, :mode => 010644))
-      allow(Etc).to receive(:getpwuid).with(123).and_return(double('Passwd', :name => 'testuser'))
-      allow(Etc).to receive(:getgrgid).with(123).and_return(double('Passwd', :name => 'testgroup'))
+      allow(File::Stat).to receive(:new).with(file).and_return(instance_double('File::Stat', uid: 123, gid: 123, mode: 0o10644))
+      allow(Etc).to receive(:getpwuid).with(123).and_return(instance_double('Passwd', name: 'testuser'))
+      allow(Etc).to receive(:getgrgid).with(123).and_return(instance_double('Passwd', name: 'testgroup'))
 
       expect(provider_class.load_file(file)).to eq [
         'testcontent', 'testuser', 'testgroup', '0644'
@@ -108,152 +106,154 @@ describe provider_class do
   end
 
   describe 'self.chown_file' do
-    before :each do
-      allow(File).to receive(:chown)
-    end
-
-    it 'should not do anything if both args are nil' do
+    it 'does not do anything if both args are nil' do
+      expect(File).not_to receive(:chown)
       provider_class.chown_file('/test/vault-secrets/test.json', nil, nil)
-      expect(File).not_to have_received(:chown)
     end
 
-    it 'should change file ownership and group when given user and group' do
-		  allow(Etc).to receive(:getpwnam).with('testuser').and_return(double('Passwd', :uid => 123))
-		  allow(Etc).to receive(:getgrnam).with('testgroup').and_return(double('Passwd', :gid => 123))
+    it 'changes file ownership and group when given user and group' do
+      expect(Etc).to receive(:getpwnam).with('testuser').and_return(instance_double('Passwd', uid: 123))
+      expect(Etc).to receive(:getgrnam).with('testgroup').and_return(instance_double('Passwd', gid: 123))
+      expect(File).to receive(:chown).with(123, 123, '/test/vault-secrets/test.json')
+
       provider_class.chown_file('/test/vault-secrets/test.json', 'testuser', 'testgroup')
-      expect(File).to have_received(:chown).with(123, 123, '/test/vault-secrets/test.json')
     end
 
-    it 'should change file ownership when given user only' do
-		  allow(Etc).to receive(:getpwnam).with('testuser').and_return(double('Passwd', :uid => 123))
-		  allow(Etc).to receive(:getgrnam)
+    it 'changes file ownership when given user only' do
+      expect(Etc).to receive(:getpwnam).with('testuser').and_return(instance_double('Passwd', uid: 123))
+      expect(Etc).not_to receive(:getgrnam)
+      expect(File).to receive(:chown).with(123, nil, '/test/vault-secrets/test.json')
+
       provider_class.chown_file('/test/vault-secrets/test.json', 'testuser', nil)
-      expect(File).to have_received(:chown).with(123, nil, '/test/vault-secrets/test.json')
-      expect(Etc).not_to have_received(:getgrnam)
     end
 
-    it 'should change file group when given group only' do
-		  allow(Etc).to receive(:getpwnam)
-      allow(Etc).to receive(:getgrnam).with('testgroup').and_return(double('Passwd', :gid => 123))
+    it 'changes file group when given group only' do
+      expect(Etc).not_to receive(:getpwnam)
+      expect(Etc).to receive(:getgrnam).with('testgroup').and_return(instance_double('Passwd', gid: 123))
+      expect(File).to receive(:chown).with(nil, 123, '/test/vault-secrets/test.json')
+
       provider_class.chown_file('/test/vault-secrets/test.json', nil, 'testgroup')
-      expect(File).to have_received(:chown).with(nil, 123, '/test/vault-secrets/test.json')
-      expect(Etc).not_to have_received(:getpwnam)
     end
   end
-  
+
   describe 'self.chmod_file' do
-    before :each do
-      allow(File).to receive(:chmod)
-    end
-
-    it 'should not change file permissions if given nil' do
+    it 'does not change file permissions if given nil' do
+      expect(File).not_to receive(:chmod)
       provider_class.chmod_file('/test/vault-secrets/test.json', nil)
-      expect(File).not_to have_received(:chmod)
     end
 
-    it 'should change the file permissions with the correct mode when given 0600' do
+    it 'changes the file permissions with the correct mode when given 0600' do
+      expect(File).to receive(:chmod).with(0o600, '/test/vault-secrets/test.json')
       provider_class.chmod_file('/test/vault-secrets/test.json', '0600')
-      expect(File).to have_received(:chmod).with(0600, '/test/vault-secrets/test.json')
     end
 
-    it 'should change the file permissions with the correct mode when given 0644' do
+    it 'changes the file permissions with the correct mode when given 0644' do
+      expect(File).to receive(:chmod).with(0o644, '/test/vault-secrets/test.json')
       provider_class.chmod_file('/test/vault-secrets/test.json', '0644')
-      expect(File).to have_received(:chmod).with(0644, '/test/vault-secrets/test.json')
     end
   end
 
   describe 'self.delete_if_exists' do
-    before :each do
-      allow(File).to receive(:delete)
-    end 
+    it 'does not delete file if given nil' do
+      expect(File).not_to receive(:exist?)
+      expect(File).not_to receive(:delete)
 
-    it 'should not delete file if given nil' do
-      allow(File).to receive(:exist?)
       provider_class.delete_if_exists(nil)
-      expect(File).not_to have_received(:exist?)
-      expect(File).not_to have_received(:delete)
     end
 
-    it 'should not delete file if given empty string' do
-      allow(File).to receive(:exist?)
+    it 'does not delete file if given empty string' do
+      expect(File).not_to receive(:exist?)
+      expect(File).not_to receive(:delete)
+
       provider_class.delete_if_exists('')
-      expect(File).not_to have_received(:exist?)
-      expect(File).not_to have_received(:delete)
     end
 
-    it 'should not try to delete file if if it doesn\'t exist' do
-      allow(File).to receive(:exist?).and_return(false)
+    it "does not try to delete file if if it doesn't exist" do
+      expect(File).to receive(:exist?).with('/test/vault-secrets/test.json').and_return(false)
+      expect(File).not_to receive(:delete)
+
       provider_class.delete_if_exists('/test/vault-secrets/test.json')
-      expect(File).to have_received(:exist?).with('/test/vault-secrets/test.json')
-      expect(File).not_to have_received(:delete)
     end
- 
-    it 'should delete a valid existing file' do
-      allow(File).to receive(:exist?).with('/test/vault-secrets/test.json').and_return(true)
+
+    it 'deletes a valid existing file' do
+      expect(File).to receive(:exist?).with('/test/vault-secrets/test.json').and_return(true)
+      expect(File).to receive(:delete).with('/test/vault-secrets/test.json')
+
       provider_class.delete_if_exists('/test/vault-secrets/test.json')
-      expect(File).to have_received(:exist?).with('/test/vault-secrets/test.json')
-      expect(File).to have_received(:delete).with('/test/vault-secrets/test.json')
     end
   end
 
   describe 'expires_soon_or_expired' do
+    let(:reference_time) { 1_609_459_200 }  # Midnight 1st Jan 2021
+
     before :each do
-      @reference_time = 1609459200  # Midnight 1st Jan 2021
-      allow(Time).to receive(:now).and_return(double('Time', :to_i => @reference_time))
+      expect(Time).to receive(:now).and_return(instance_double('Time', to_i: reference_time))
     end
 
-    it 'should return false if expiry time is far in the future' do
-      resource = type_class.new(name: 'test', :renewal_threshold => 3, :provider => provider_class.name)
+    it 'returns false if expiry time is far in the future' do
+      resource = type_class.new(name: 'test', renewal_threshold: 3, provider: provider_class.name)
       instance = provider_class.new(resource)
-      instance.instance_variable_get(:@property_hash)[:expiration] = @reference_time + (100 * 86400)
+      instance.instance_variable_get(:@property_hash)[:expiration] = reference_time + (100 * 86_400)
       expect(instance.expires_soon_or_expired).to be false
     end
 
-    it 'should return true if expiry time is in the near future' do
-      resource = type_class.new(name: 'test', :renewal_threshold => 3, :provider => provider_class.name)
+    it 'returns true if expiry time is in the near future' do
+      resource = type_class.new(name: 'test', renewal_threshold: 3, provider: provider_class.name)
       instance = provider_class.new(resource)
-      instance.instance_variable_get(:@property_hash)[:expiration] = @reference_time + 86400
+      instance.instance_variable_get(:@property_hash)[:expiration] = reference_time + 86_400
       expect(instance.expires_soon_or_expired).to be true
     end
 
-    it 'should return true if expiry time has already passed' do
-      resource = type_class.new(name: 'test', :renewal_threshold => 3, :provider => provider_class.name)
+    it 'returns true if expiry time has already passed' do
+      resource = type_class.new(name: 'test', renewal_threshold: 3, provider: provider_class.name)
       instance = provider_class.new(resource)
-      instance.instance_variable_get(:@property_hash)[:expiration] = @reference_time - 86400
+      instance.instance_variable_get(:@property_hash)[:expiration] = reference_time - 86_400
       expect(instance.expires_soon_or_expired).to be true
     end
   end
 
   describe 'needs_reissue?' do
+    let(:resource) do
+      type_class.new({
+                       name: 'test',
+      provider: provider_class.name
+                     })
+    end
+    let(:instance) { provider_class.new(resource) }
+
     before :each do
-      @instance = provider_class.new(name: 'test', :ensure => :present, :cert_data => {
+      instance.instance_variable_get(:@property_hash)[:ensure] = :present
+      instance.instance_variable_get(:@property_hash)[:cert_data] = {
         'common_name': 'test.example.com',
-      })
-      allow(@instance).to receive(:expires_soon_or_expired).and_return(false)
+      }
     end
 
-    it 'should reissue if it doesn\'t already exist' do
-      @instance.instance_variable_get(:@property_hash)[:ensure] = :absent
-      expect(@instance.needs_issue?). to be true
+    it "reissues if it doesn't already exist" do
+      instance.instance_variable_get(:@property_hash)[:ensure] = :absent
+      expect(instance).not_to receive(:expires_soon_or_expired)
+      expect(instance.needs_issue?).to be true
     end
 
-    it 'should reissue if the cert_data has changed' do
-      @instance.cert_data = {'common_name': 'test2.example.com'}
-      expect(@instance.needs_issue?). to be true
+    it 'reissues if the cert_data has changed' do
+      instance.cert_data = { 'common_name': 'test2.example.com' }
+      expect(instance).not_to receive(:expires_soon_or_expired)
+      expect(instance.needs_issue?).to be true
     end
 
-    it 'should not reissue if the cert_data is flagged for change but has the same value' do
-      @instance.cert_data = {'common_name': 'test.example.com'}
-      expect(@instance.needs_issue?). to be false
+    it 'does not reissue if the cert_data is flagged for change but has the same value' do
+      instance.cert_data = { 'common_name': 'test.example.com' }
+      expect(instance).to receive(:expires_soon_or_expired).and_return(false)
+      expect(instance.needs_issue?).to be false
     end
 
-    it 'should reissue if expires soon or already expired' do
-      allow(@instance).to receive(:expires_soon_or_expired).and_return(true)
-      expect(@instance.needs_issue?). to be true
+    it 'reissues if expires soon or already expired' do
+      expect(instance).to receive(:expires_soon_or_expired).and_return(true)
+      expect(instance.needs_issue?).to be true
     end
 
-    it 'should not reissue if all conditions hold' do
-      expect(@instance.needs_issue?). to be false
+    it 'does not reissue if all conditions hold' do
+      expect(instance).to receive(:expires_soon_or_expired).and_return(false)
+      expect(instance.needs_issue?).to be false
     end
   end
 
@@ -262,61 +262,59 @@ describe provider_class do
       allow(File).to receive(:exist?)
     end
 
-		#'/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
-		#'/etc/ssl/certs/ca-certificates.crt'
+    # '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    # '/etc/ssl/certs/ca-certificates.crt'
 
-    it 'should return find the first certificate bundle when it exists' do
-      allow(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(true)
+    it 'returns find the first certificate bundle when it exists' do
+      expect(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(true)
       expect(provider_class.get_ca_trust).to eq '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
     end
 
-    it 'should return find the second certificate bundle when it exists' do
-      allow(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(false)
-      allow(File).to receive(:exist?).with('/etc/ssl/certs/ca-certificates.crt').and_return(true)
+    it 'returns find the second certificate bundle when it exists' do
+      expect(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(false)
+      expect(File).to receive(:exist?).with('/etc/ssl/certs/ca-certificates.crt').and_return(true)
       expect(provider_class.get_ca_trust).to eq '/etc/ssl/certs/ca-certificates.crt'
     end
 
-    it 'should raise an error when neither certificate bundle exists' do
-      allow(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(false)
-      allow(File).to receive(:exist?).with('/etc/ssl/certs/ca-certificates.crt').and_return(false)
-      expect do
+    it 'raises an error when neither certificate bundle exists' do
+      expect(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(false)
+      expect(File).to receive(:exist?).with('/etc/ssl/certs/ca-certificates.crt').and_return(false)
+      expect {
         provider_class.get_ca_trust
-      end.to raise_error(Puppet::Error, 'Failed to get the trusted CA certificate file')
+      }.to raise_error(Puppet::Error, 'Failed to get the trusted CA certificate file')
     end
   end
 
   describe 'issue_cert' do
-		#http = http_create_secure(uri, ca_trust, @resource[:timeout])
-		#token = vault_get_token(http, @resource[:auth_path].delete('/'))
-		#secrets = vault_http_post(http, uri.path, token, @resource[:cert_data])
-		#response = vault_parse_data(secrets)
-
-    before :each do
-      allow(provider_class).to receive(:get_ca_trust).and_return('/test/ca.crt')
-      allow_any_instance_of(provider_class).to receive(:http_create_secure).and_return(1)
-      allow_any_instance_of(provider_class).to receive(:vault_get_token).and_return('secrettoken')
-      allow_any_instance_of(provider_class).to receive(:vault_http_post).and_return('secrets')
-      allow_any_instance_of(provider_class).to receive(:vault_parse_data).with('secrets').and_return('secrets')
+    context 'when given an invalid URI' do
+      it 'raises an exception' do
+        resource = type_class.new({ name: 'test', vault_uri: 'invalid', provider: provider_class.name })
+        instance = provider_class.new(resource)
+        expect(instance).to receive(:URI).and_return(instance_double('URI::HTTP', hostname: nil))
+        expect {
+          instance.issue_cert
+        }.to raise_error(Puppet::Error, %r{Unable to parse a hostname})
+      end
     end
 
-    it 'should raise an exception when given an invalid URI' do
-      allow(URI).to receive(:new).and_return(double('URI::HTTP', :hostname => nil))
-      resource = type_class.new({:name => 'test', :vault_uri => 'invalid', :provider => provider_class.name})
-      instance = provider_class.new(resource)
-      expect do
-        instance.issue_cert
-      end.to raise_error(Puppet::Error, /Unable to parse a hostname/)
-    end
+    context 'when given a valid URI' do
+      let(:uri) { instance_double('URI::HTTP', hostname: 'vault.example.com', path: '/pki/issue/cert') }
 
-    it 'should obtain a new cert from vault when given a valid URI' do
-      allow(URI).to receive(:new).and_return(double('URI::HTTP', :hostname => 'vault.example.com', :path => '/'))
-      resource = type_class.new({:name => 'test', :vault_uri => 'http://vault.example.com/pki/issue/cert', :cert_data => {'common_name': 'test.example.com'}, :timeout => 9, :provider => provider_class.name})
-      instance = provider_class.new(resource)
-      expect(instance.issue_cert).to eq 'secrets'
-      expect(instance).to have_received(:http_create_secure).with(URI('http://vault.example.com/pki/issue/cert'), '/test/ca.crt', 9)
-      expect(instance).to have_received(:vault_get_token).with(1, 'puppet-pki')
-      expect(instance).to have_received(:vault_http_post).with(1, '/pki/issue/cert', 'secrettoken', {'common_name': 'test.example.com'})
-      expect(instance).to have_received(:vault_parse_data).with('secrets')
+      before :each do
+        expect(provider_class).to receive(:get_ca_trust).and_return('/test/ca.crt')
+      end
+
+      it 'obtains a new cert from vault' do
+        resource = type_class.new({ name: 'test', vault_uri: 'http://vault.example.com/pki/issue/cert', cert_data: { 'common_name': 'test.example.com' }, timeout: 9,
+  provider: provider_class.name })
+        instance = provider_class.new(resource)
+        expect(instance).to receive(:URI).and_return(uri)
+        expect(instance).to receive(:http_create_secure).with(uri, '/test/ca.crt', 9).and_return(:http)
+        expect(instance).to receive(:vault_get_token).with(:http, 'puppet-pki').and_return('secrettoken')
+        expect(instance).to receive(:vault_http_post).with(:http, '/pki/issue/cert', 'secrettoken', { 'common_name': 'test.example.com' }).and_return('response')
+        expect(instance).to receive(:vault_parse_data).with('response').and_return('secrets')
+        expect(instance.issue_cert).to eq 'secrets'
+      end
     end
   end
 
@@ -328,76 +326,73 @@ describe provider_class do
       ['key', '/test/vault-secrets/test.key', :key_owner, :key_group, :key_mode],
     ].each do |file_attributes|
       file_name, path, owner, group, mode = file_attributes
+      let(:instance) do
+        resource = type_class.new({ name: 'test', provider: provider_class.name })
+        provider_class.new(resource)
+      end
 
       describe "when updating #{file_name} file" do
-        before :each do
-          @resource = type_class.new({:name => 'test', :provider => provider_class.name})
-          @instance = provider_class.new(@resource)
-          allow(provider_class).to receive(:chown_file)
-          allow(provider_class).to receive(:chmod_file)
+        it 'does nothing when all attributes are in sync' do
+          expect(provider_class).not_to receive(:chown_file)
+          expect(provider_class).not_to receive(:chmod_file)
+          instance.flush_file_attributes(path, owner, group, mode, false)
         end
 
-        it 'should do nothing when all attributes are in sync' do
-          @instance.flush_file_attributes(path, owner, group, mode, false)
-          expect(provider_class).not_to have_received(:chown_file)
-          expect(provider_class).not_to have_received(:chmod_file)
+        it 'does nothing when change is signalled to owner but already in sync' do
+          expect(provider_class).not_to receive(:chown_file)
+          expect(provider_class).not_to receive(:chmod_file)
+          instance.instance_variable_get(:@property_hash)[owner] = 'testuser'
+          instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
+          instance.flush_file_attributes(path, owner, group, mode, false)
         end
 
-        it 'should do nothing when change is signalled to owner but already in sync' do
-          @instance.instance_variable_get(:@property_hash)[owner] = 'testuser'
-          @instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
-          @instance.flush_file_attributes(path, owner, group, mode, false)
-          expect(provider_class).not_to have_received(:chown_file)
-          expect(provider_class).not_to have_received(:chmod_file)
+        it 'does nothing when change is signalled to group but already in sync' do
+          expect(provider_class).not_to receive(:chown_file)
+          expect(provider_class).not_to receive(:chmod_file)
+          instance.instance_variable_get(:@property_hash)[group] = 'testgroup'
+          instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
+          instance.flush_file_attributes(path, owner, group, mode, false)
         end
 
-        it 'should do nothing when change is signalled to group but already in sync' do
-          @instance.instance_variable_get(:@property_hash)[group] = 'testgroup'
-          @instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
-          @instance.flush_file_attributes(path, owner, group, mode, false)
-          expect(provider_class).not_to have_received(:chown_file)
-          expect(provider_class).not_to have_received(:chmod_file)
+        it 'does nothing when change is signalled to mode but already in sync' do
+          expect(provider_class).not_to receive(:chown_file)
+          expect(provider_class).not_to receive(:chmod_file)
+          instance.instance_variable_get(:@property_hash)[mode] = '0600'
+          instance.instance_variable_get(:@property_flush)[mode] = '0600'
+          instance.flush_file_attributes(path, owner, group, mode, false)
         end
 
-        it 'should do nothing when change is signalled to mode but already in sync' do
-          @instance.instance_variable_get(:@property_hash)[mode] = '0600'
-          @instance.instance_variable_get(:@property_flush)[mode] = '0600'
-          @instance.flush_file_attributes(path, owner, group, mode, false)
-          expect(provider_class).not_to have_received(:chown_file)
-          expect(provider_class).not_to have_received(:chmod_file)
+        it 'updates ownership when change is signalled to owner' do
+          expect(provider_class).to receive(:chown_file).with(path, 'testuser', nil)
+          expect(provider_class).not_to receive(:chmod_file)
+          instance.instance_variable_get(:@property_hash)[owner] = 'otheruser'
+          instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
+          instance.flush_file_attributes(path, owner, group, mode, false)
         end
 
-        it 'should update ownership when change is signalled to owner' do
-          @instance.instance_variable_get(:@property_hash)[owner] = 'otheruser'
-          @instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
-          @instance.flush_file_attributes(path, owner, group, mode, false)
-          expect(provider_class).to have_received(:chown_file).with(path, 'testuser', nil)
-          expect(provider_class).not_to have_received(:chmod_file)
+        it 'updates ownership when change is signalled to group' do
+          expect(provider_class).to receive(:chown_file).with(path, nil, 'testgroup')
+          expect(provider_class).not_to receive(:chmod_file)
+          instance.instance_variable_get(:@property_hash)[group] = 'othergroup'
+          instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
+          instance.flush_file_attributes(path, owner, group, mode, false)
         end
 
-        it 'should update ownership when change is signalled to group' do
-          @instance.instance_variable_get(:@property_hash)[group] = 'othergroup'
-          @instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
-          @instance.flush_file_attributes(path, owner, group, mode, false)
-          expect(provider_class).to have_received(:chown_file).with(path, nil, 'testgroup')
-          expect(provider_class).not_to have_received(:chmod_file)
+        it 'updates permissions when change is signalled' do
+          expect(provider_class).not_to receive(:chown_file)
+          expect(provider_class).to receive(:chmod_file).with(path, '0600')
+          instance.instance_variable_get(:@property_hash)[mode] = '0644'
+          instance.instance_variable_get(:@property_flush)[mode] = '0600'
+          instance.flush_file_attributes(path, owner, group, mode, false)
         end
 
-        it 'should update permissions when change is signalled' do
-          @instance.instance_variable_get(:@property_hash)[mode] = '0644'
-          @instance.instance_variable_get(:@property_flush)[mode] = '0600'
-          @instance.flush_file_attributes(path, owner, group, mode, false)
-          expect(provider_class).not_to have_received(:chown_file)
-          expect(provider_class).to have_received(:chmod_file).with(path, '0600')
-        end
-
-        it 'should update ownership and mode when change is forced' do
-          @instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
-          @instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
-          @instance.instance_variable_get(:@property_flush)[mode] = '0600'
-          @instance.flush_file_attributes(path, owner, group, mode, true)
-          expect(provider_class).to have_received(:chown_file).with(path, 'testuser', 'testgroup')
-          expect(provider_class).to have_received(:chmod_file).with(path, '0600')
+        it 'updates ownership and mode when change is forced' do
+          expect(provider_class).to receive(:chown_file).with(path, 'testuser', 'testgroup')
+          expect(provider_class).to receive(:chmod_file).with(path, '0600')
+          instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
+          instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
+          instance.instance_variable_get(:@property_flush)[mode] = '0600'
+          instance.flush_file_attributes(path, owner, group, mode, true)
         end
       end
     end
@@ -412,147 +407,143 @@ describe provider_class do
       file_name, target, path, content, owner, group, mode = file_attributes
 
       describe "when updating #{file_name} file" do
+        let(:info_file_target) { '/test/vault-secrets/test.json' }
+        let(:resource) { type_class.new({ :name => 'test', path => target, owner => 'testuser', group => 'testgroup', mode => '0600', :provider => provider_class.name }) }
+        let(:instance) { provider_class.new(resource) }
 
         before :each do
-          allow(File).to receive(:write)
-          @info_file_target = '/test/vault-secrets/test.json'
-          @resource = type_class.new({:name => 'test', path => target, owner => 'testuser', group => 'testgroup', mode => '0600', :provider => provider_class.name})
-          @instance = provider_class.new(@resource)
           # Derived property can't be set at object creation time due to validation
           # must be injected into the existing object, as would happen at runtime
-          property_hash = @instance.instance_variable_get(:@property_hash)
+          property_hash = instance.instance_variable_get(:@property_hash)
           property_hash[content] = 'testcontent'
           property_hash[path] = target
-          allow(provider_class).to receive(:delete_if_exists)
-          allow(@instance).to receive(:flush_file_attributes)
         end
 
         describe 'should force reset file attributes if the destination file did not previously exist' do
           it 'because content is not present in property hash' do
-            @instance.instance_variable_get(:@property_hash).delete(content)
-            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
-            @instance.flush_file(path, content, owner, group, mode)
-            expect(File).to have_received(:write).with(target, 'testcontent')
-            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, true)
+            expect(File).to receive(:write).with(target, 'testcontent')
+            expect(instance).to receive(:flush_file_attributes).with(target, owner, group, mode, true)
+            instance.instance_variable_get(:@property_hash).delete(content)
+            instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            instance.flush_file(path, content, owner, group, mode)
           end
 
           it 'because content is present in property hash but is nil' do
-            @instance.instance_variable_get(:@property_hash)[content] = nil
-            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
-            @instance.flush_file(path, content, owner, group, mode)
-            expect(File).to have_received(:write).with(target, 'testcontent')
-            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, true)
+            expect(File).to receive(:write).with(target, 'testcontent')
+            expect(instance).to receive(:flush_file_attributes).with(target, owner, group, mode, true)
+            instance.instance_variable_get(:@property_hash)[content] = nil
+            instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            instance.flush_file(path, content, owner, group, mode)
           end
 
           it 'because content is present in the property hash but is blank' do
-            @instance.instance_variable_get(:@property_hash)[content] = ''
-            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
-            @instance.flush_file(path, content, owner, group, mode)
-            expect(File).to have_received(:write).with(target, 'testcontent')
-            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, true)
+            expect(File).to receive(:write).with(target, 'testcontent')
+            expect(instance).to receive(:flush_file_attributes).with(target, owner, group, mode, true)
+            instance.instance_variable_get(:@property_hash)[content] = ''
+            instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            instance.flush_file(path, content, owner, group, mode)
           end
         end
-        
-        it 'should force reset file attributes if the file path is being changed' do
-            @instance.instance_variable_get(:@property_hash)[path] = '/test/vault-secrets/old-path.txt'
-            @instance.instance_variable_get(:@property_flush)[path] = target
-            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
-            @instance.flush_file(path, content, owner, group, mode)
-            expect(File).to have_received(:write).with(target, 'testcontent')
-            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, true)
+
+        it 'forces reset file attributes if the file path is being changed' do
+          expect(File).to receive(:write).with(target, 'testcontent')
+          expect(instance).to receive(:flush_file_attributes).with(target, owner, group, mode, true)
+          instance.instance_variable_get(:@property_hash)[path] = '/test/vault-secrets/old-path.txt'
+          instance.instance_variable_get(:@property_flush)[path] = target
+          instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+          instance.flush_file(path, content, owner, group, mode)
         end
 
-        it 'should delete the original file if the path is being changed' do
-            @instance.instance_variable_get(:@property_hash)[path] = '/test/vault-secrets/old-path.txt'
-            @instance.instance_variable_get(:@property_flush)[path] = target
-            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
-            @instance.flush_file(path, content, owner, group, mode)
-            expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/old-path.txt')
+        it 'deletes the original file if the path is being changed' do
+          expect(File).to receive(:write).with(target, 'testcontent')
+          expect(provider_class).to receive(:delete_if_exists).with('/test/vault-secrets/old-path.txt')
+          expect(instance).to receive(:flush_file_attributes)
+          instance.instance_variable_get(:@property_hash)[path] = '/test/vault-secrets/old-path.txt'
+          instance.instance_variable_get(:@property_flush)[path] = target
+          instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+          instance.flush_file(path, content, owner, group, mode)
         end
 
-        it 'should update the file if a change is signalled to the contents' do
-            @instance.instance_variable_get(:@property_hash)[content] = 'oldcontent'
-            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
-            @instance.flush_file(path, content, owner, group, mode)
-            expect(provider_class).not_to have_received(:delete_if_exists)
-            expect(File).to have_received(:write).with(target, 'testcontent')
-            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, false)
+        it 'updates the file if a change is signalled to the contents' do
+          expect(provider_class).not_to receive(:delete_if_exists)
+          expect(File).to receive(:write).with(target, 'testcontent')
+          expect(instance).to receive(:flush_file_attributes).with(target, owner, group, mode, false)
+          instance.instance_variable_get(:@property_hash)[content] = 'oldcontent'
+          instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+          instance.flush_file(path, content, owner, group, mode)
         end
 
-        it 'should not rewrite the file if a change of contents is signalled but is already in sync' do
-            @instance.instance_variable_get(:@property_hash)[content] = 'testcontent'
-            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
-            @instance.flush_file(path, content, owner, group, mode)
-            expect(provider_class).not_to have_received(:delete_if_exists)
-            expect(File).not_to have_received(:write)
-            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, false)
+        it 'does not rewrite the file if a change of contents is signalled but is already in sync' do
+          expect(provider_class).not_to receive(:delete_if_exists)
+          expect(File).not_to receive(:write)
+          expect(instance).to receive(:flush_file_attributes).with(target, owner, group, mode, false)
+          instance.instance_variable_get(:@property_hash)[content] = 'testcontent'
+          instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+          instance.flush_file(path, content, owner, group, mode)
         end
       end
     end
   end
 
   describe 'flush' do
-    before :each do
-      @resource = type_class.new({
-        :name => 'test',
-        :ensure => :present,
-        :ca_chain_file => '/test/vault-secrets/test.chain.crt',
-        :cert_file => '/test/vault-secrets/test.crt',
-        :key_file => '/test/vault-secrets/test.key',
-        :provider => provider_class.name})
-      @instance = provider_class.new(@resource)
-      allow(provider_class).to receive(:delete_if_exists)
-      allow(@instance).to receive(:flush_file_attributes)
-      allow(@instance).to receive(:flush_file)
-      allow(@instance).to receive(:needs_issue?).and_return(false)
-      allow(@instance).to receive(:issue_cert).and_return({
-        'ca_chain' => ['testchain'],
-        'issuing_ca' => 'testchain',
-        'certificate' => 'testcert',
-        'private_key' => 'testkey',
-      })
-      allow(JSON).to receive(:generate).and_return('testdata')
-      allow(JSON).to receive(:parse).and_return({'data' => { 'ca_chain' => ['testchain'], 'certificate' => 'testcert', 'private_key' => 'testkey'}})
-      allow(File).to receive(:read).and_return('testdata')
-      allow(File).to receive(:write)
+    let(:instance) do
+      type_class.new({ name: 'test',
+                      ensure: :present,
+                      ca_chain_file: '/test/vault-secrets/test.chain.crt',
+                      cert_file: '/test/vault-secrets/test.crt',
+                      key_file: '/test/vault-secrets/test.key',
+                      provider: provider_class.name })
+      provider_class.new(resource)
     end
 
-    it 'should delete all files if ensure is set to absent' do
-      @instance.instance_variable_get(:@property_flush)[:ensure] = :absent
-      @instance.flush
-      expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/test.chain.crt')
-      expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/test.crt')
-      expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/test.key')
-      expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/test.json')
-    end
-    
-    it 'should not delete any files if ensure is not set to absent' do
-      @instance.flush
-      expect(provider_class).not_to have_received(:delete_if_exists)
+    it 'deletes all files if ensure is set to absent' do
+      expect(provider_class).to receive(:delete_if_exists).with('/test/vault-secrets/test.chain.crt')
+      expect(provider_class).to receive(:delete_if_exists).with('/test/vault-secrets/test.crt')
+      expect(provider_class).to receive(:delete_if_exists).with('/test/vault-secrets/test.key')
+      expect(provider_class).to receive(:delete_if_exists).with('/test/vault-secrets/test.json')
+      expect(File).not_to receive(:write)
+      expect(instance).not_to receive(:flush_file_attributes)
+      expect(instance).not_to receive(:flush_file)
+      instance.instance_variable_get(:@property_flush)[:ensure] = :absent
+      instance.flush
     end
 
-    it 'should issue a new cert if needed and update all files' do
-      allow(@instance).to receive(:needs_issue?).and_return(true)
-      @instance.flush
-      expect(@instance).to have_received(:issue_cert)
-      expect(JSON).to have_received(:generate)
-      expect(File).to have_received(:write).with('/test/vault-secrets/test.json', 'testdata')
-      expect(@instance).to have_received(:flush_file_attributes).with('/test/vault-secrets/test.json', :info_owner, :info_group, :info_mode, true)
-      expect(@instance).to have_received(:flush_file).with(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
-      expect(@instance).to have_received(:flush_file).with(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
-      expect(@instance).to have_received(:flush_file).with(:key_file, :key, :key_owner, :key_group, :key_mode)
+    it 'does not delete any files if ensure is set to present' do
+      expect(provider_class).not_to receive(:delete_if_exists)
+      expect(instance).to receive(:needs_issue?).and_return(false)
+      expect(File).to receive(:read).with('/test/vault-secrets/test.json').and_return('testdata')
+      expect(JSON).to receive(:parse).with('testdata').and_return({ 'data' => { 'ca_chain' => ['testchain'], 'certificate' => 'testcert', 'private_key' => 'testkey' } })
+      expect(instance).to receive(:flush_file_attributes)
+      expect(instance).to receive(:flush_file).exactly(3).times
+      instance.flush
     end
 
-    it 'should not issue a new cert if not needed' do
-      @instance.flush
-      expect(@instance).not_to have_received(:issue_cert)
-      expect(File).not_to have_received(:write)
-      expect(File).to have_received(:read).with('/test/vault-secrets/test.json')
-      expect(JSON).to have_received(:parse).with('testdata')
-      expect(@instance).to have_received(:flush_file_attributes).with('/test/vault-secrets/test.json', :info_owner, :info_group, :info_mode)
-      expect(@instance).to have_received(:flush_file).with(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
-      expect(@instance).to have_received(:flush_file).with(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
-      expect(@instance).to have_received(:flush_file).with(:key_file, :key, :key_owner, :key_group, :key_mode)
+    it 'issues a new cert if needed and update all files' do
+      expect(instance).to receive(:needs_issue?).and_return(true)
+      expect(instance).to receive(:issue_cert).and_return({ 'ca_chain' => ['testchain'],
+                                                          'issuing_ca' => 'testchain',
+                                                          'certificate' => 'testcert',
+                                                          'private_key' => 'testkey', })
+      expect(JSON).to receive(:generate).and_return('testdata')
+      expect(File).to receive(:write).with('/test/vault-secrets/test.json', 'testdata')
+      expect(instance).to receive(:flush_file_attributes).with('/test/vault-secrets/test.json', :info_owner, :info_group, :info_mode, true)
+      expect(instance).to receive(:flush_file).with(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
+      expect(instance).to receive(:flush_file).with(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
+      expect(instance).to receive(:flush_file).with(:key_file, :key, :key_owner, :key_group, :key_mode)
+      instance.flush
+    end
+
+    it 'does not issue a new cert if not needed' do
+      expect(instance).to receive(:needs_issue?).and_return(false)
+      expect(instance).not_to receive(:issue_cert)
+      expect(File).not_to receive(:write)
+      expect(JSON).to receive(:parse).with('testdata').and_return({ 'data' => { 'ca_chain' => ['testchain'], 'certificate' => 'testcert', 'private_key' => 'testkey' } })
+      expect(File).to receive(:read).with('/test/vault-secrets/test.json').and_return('testdata')
+      expect(instance).to receive(:flush_file_attributes).with('/test/vault-secrets/test.json', :info_owner, :info_group, :info_mode)
+      expect(instance).to receive(:flush_file).with(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
+      expect(instance).to receive(:flush_file).with(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
+      expect(instance).to receive(:flush_file).with(:key_file, :key, :key_owner, :key_group, :key_mode)
+      instance.flush
     end
   end
 end

--- a/spec/unit/provider/ruby_spec.rb
+++ b/spec/unit/provider/ruby_spec.rb
@@ -1,0 +1,558 @@
+require 'json'
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:vault_cert)
+provider_class = type_class.provider(:ruby)
+
+describe provider_class do
+  let(:resource) {
+    Puppet::Type.type(:vault_cert).new({ name: 'test', :provider => described_class.name})
+  }
+  let(:provider) { resource.provider }
+
+  before :each do
+    allow(Facter).to receive(:value).with(:vault_cert_dir).and_return('/test/vault-secrets')
+  end
+
+  it 'should have the correct vault_cert_dir' do
+    resource = described_class.new(name: 'test', ensure: :present, cert_data: {}, expiration: 123)
+    expect(resource.instance_variable_get(:@cert_dir)).to eq '/test/vault-secrets'
+  end
+
+  describe 'when loading existing instances' do
+    before :each do
+      info_files = {
+        '/test/vault-secrets/test.json' => {
+          :contents => '{"data":{"expiration": 123, "ca_chain": ["testchain"], "issuing_ca": "testca", "certificate": "testcert", "private_key": "testkey"}, "cert_data": {}, "ca_chain_file": "/test/vault-secrets/test.chain.crt", "cert_file": "/test/vault-secrets/test.crt", "key_file": "/test/vault-secrets/test.key" }',
+        },
+        '/test/vault-secrets/test2.json' => {
+          :contents => '{"data":{"expiration": 123, "ca_chain": ["testchain2"], "issuing_ca": "testca2", "certificate": "testcert2", "private_key": "testkey2"}, "cert_data": {}, "ca_chain_file": "/test/vault-secrets/test2.chain.crt", "cert_file": "/test/vault-secrets/test2.crt", "key_file": "/test/vault-secrets/test2.key" }',
+        }
+      }
+
+      allow(Dir).to receive(:glob).with('/test/vault-secrets/*.json').and_return(info_files.keys)
+      info_files.each do |filename, details|
+        info = JSON.parse(details[:contents])
+        allow(provider_class).to receive(:load_file).with(filename).and_return([details[:contents], 'root', 'root', '0644'])
+        allow(provider_class).to receive(:load_file).with(info['ca_chain_file']).and_return([info['data']['ca_chain'], 'root', 'root', '0644'])
+        allow(provider_class).to receive(:load_file).with(info['cert_file']).and_return([info['data']['certificate'], 'root', 'root', '0644'])
+        allow(provider_class).to receive(:load_file).with(info['key_file']).and_return([info['data']['private_key'], 'root', 'root', '0600'])
+      end
+    end
+
+    describe 'self.instances' do
+      it 'returns an aray of certificate data' do
+        instances = provider_class.instances.collect { |x| x.name }
+        expect(instances).to contain_exactly('test', 'test2')
+      end
+    end
+
+    describe 'self.prefetch' do
+      it 'associates defined resources in the catalog with corresponding discovered instances on the system' do
+        defined_resources = {
+          'test1' => type_class.new(name: 'test1', provider: provider_class.name),
+          'test2' => type_class.new(name: 'test2', provider: provider_class.name),
+          'test3' => type_class.new(name: 'test3', provider: provider_class.name),
+        }
+        test1 = provider_class.new(name: 'test1', ensure: :present)
+        test2 = provider_class.new(name: 'test2', ensure: :present)
+        test4 = provider_class.new(name: 'test4', ensure: :present)
+        allow(provider_class).to receive(:instances).and_return([
+          test1, test2, test4
+        ])
+        provider.class.prefetch(defined_resources)
+        expect(defined_resources['test1'].provider).to be test1
+        expect(defined_resources['test2'].provider).to be test2
+        expect(defined_resources['test3'].provider).not_to be test4
+      end
+    end
+  end
+    
+  describe 'self.load_file' do
+    it 'should return nil when asked to load nil' do
+      allow(File).to receive(:exists?)
+      allow(File).to receive(:read)
+      allow(File).to receive(:stat)
+
+      expect(provider_class.load_file(nil)).to eq [nil, nil, nil, nil]
+
+      expect(File).not_to have_received(:exists?)
+      expect(File).not_to have_received(:read)
+      expect(File).not_to have_received(:stat)
+    end
+
+    it 'should return nil when asked to load a non-existent file' do
+      allow(File).to receive(:exists?).and_return(false)
+      allow(File).to receive(:read)
+      allow(File).to receive(:stat)
+
+      expect(provider_class.load_file('/test/vault-secrets/test.json')).to eq [nil, nil, nil, nil]
+      
+      expect(File).to have_received(:exists?).with('/test/vault-secrets/test.json')
+      expect(File).not_to have_received(:read)
+      expect(File).not_to have_received(:stat)
+    end
+
+    it 'should return file attributes when called for an existing file' do
+      file = '/test/vault-secrets/test.json'
+      allow(File).to receive(:exists?).with(file).and_return(true)
+      allow(File).to receive(:read).with(file).and_return('testcontent')
+      allow(File::Stat).to receive(:new).with(file).and_return(double('File::Stat', :uid => 123, :gid => 123, :mode => 010644))
+      allow(Etc).to receive(:getpwuid).with(123).and_return(double('Passwd', :name => 'testuser'))
+      allow(Etc).to receive(:getgrgid).with(123).and_return(double('Passwd', :name => 'testgroup'))
+
+      expect(provider_class.load_file(file)).to eq [
+        'testcontent', 'testuser', 'testgroup', '0644'
+      ]
+    end
+  end
+
+  describe 'self.chown_file' do
+    before :each do
+      allow(File).to receive(:chown)
+    end
+
+    it 'should not do anything if both args are nil' do
+      provider_class.chown_file('/test/vault-secrets/test.json', nil, nil)
+      expect(File).not_to have_received(:chown)
+    end
+
+    it 'should change file ownership and group when given user and group' do
+		  allow(Etc).to receive(:getpwnam).with('testuser').and_return(double('Passwd', :uid => 123))
+		  allow(Etc).to receive(:getgrnam).with('testgroup').and_return(double('Passwd', :gid => 123))
+      provider_class.chown_file('/test/vault-secrets/test.json', 'testuser', 'testgroup')
+      expect(File).to have_received(:chown).with(123, 123, '/test/vault-secrets/test.json')
+    end
+
+    it 'should change file ownership when given user only' do
+		  allow(Etc).to receive(:getpwnam).with('testuser').and_return(double('Passwd', :uid => 123))
+		  allow(Etc).to receive(:getgrnam)
+      provider_class.chown_file('/test/vault-secrets/test.json', 'testuser', nil)
+      expect(File).to have_received(:chown).with(123, nil, '/test/vault-secrets/test.json')
+      expect(Etc).not_to have_received(:getgrnam)
+    end
+
+    it 'should change file group when given group only' do
+		  allow(Etc).to receive(:getpwnam)
+      allow(Etc).to receive(:getgrnam).with('testgroup').and_return(double('Passwd', :gid => 123))
+      provider_class.chown_file('/test/vault-secrets/test.json', nil, 'testgroup')
+      expect(File).to have_received(:chown).with(nil, 123, '/test/vault-secrets/test.json')
+      expect(Etc).not_to have_received(:getpwnam)
+    end
+  end
+  
+  describe 'self.chmod_file' do
+    before :each do
+      allow(File).to receive(:chmod)
+    end
+
+    it 'should not change file permissions if given nil' do
+      provider_class.chmod_file('/test/vault-secrets/test.json', nil)
+      expect(File).not_to have_received(:chmod)
+    end
+
+    it 'should change the file permissions with the correct mode when given 0600' do
+      provider_class.chmod_file('/test/vault-secrets/test.json', '0600')
+      expect(File).to have_received(:chmod).with(0600, '/test/vault-secrets/test.json')
+    end
+
+    it 'should change the file permissions with the correct mode when given 0644' do
+      provider_class.chmod_file('/test/vault-secrets/test.json', '0644')
+      expect(File).to have_received(:chmod).with(0644, '/test/vault-secrets/test.json')
+    end
+  end
+
+  describe 'self.delete_if_exists' do
+    before :each do
+      allow(File).to receive(:delete)
+    end 
+
+    it 'should not delete file if given nil' do
+      allow(File).to receive(:exist?)
+      provider_class.delete_if_exists(nil)
+      expect(File).not_to have_received(:exist?)
+      expect(File).not_to have_received(:delete)
+    end
+
+    it 'should not delete file if given empty string' do
+      allow(File).to receive(:exist?)
+      provider_class.delete_if_exists('')
+      expect(File).not_to have_received(:exist?)
+      expect(File).not_to have_received(:delete)
+    end
+
+    it 'should not try to delete file if if it doesn\'t exist' do
+      allow(File).to receive(:exist?).and_return(false)
+      provider_class.delete_if_exists('/test/vault-secrets/test.json')
+      expect(File).to have_received(:exist?).with('/test/vault-secrets/test.json')
+      expect(File).not_to have_received(:delete)
+    end
+ 
+    it 'should delete a valid existing file' do
+      allow(File).to receive(:exist?).with('/test/vault-secrets/test.json').and_return(true)
+      provider_class.delete_if_exists('/test/vault-secrets/test.json')
+      expect(File).to have_received(:exist?).with('/test/vault-secrets/test.json')
+      expect(File).to have_received(:delete).with('/test/vault-secrets/test.json')
+    end
+  end
+
+  describe 'expires_soon_or_expired' do
+    before :each do
+      @reference_time = 1609459200  # Midnight 1st Jan 2021
+      allow(Time).to receive(:now).and_return(double('Time', :to_i => @reference_time))
+    end
+
+    it 'should return false if expiry time is far in the future' do
+      resource = type_class.new(name: 'test', :renewal_threshold => 3, :provider => provider_class.name)
+      instance = provider_class.new(resource)
+      instance.instance_variable_get(:@property_hash)[:expiration] = @reference_time + (100 * 86400)
+      expect(instance.expires_soon_or_expired).to be false
+    end
+
+    it 'should return true if expiry time is in the near future' do
+      resource = type_class.new(name: 'test', :renewal_threshold => 3, :provider => provider_class.name)
+      instance = provider_class.new(resource)
+      instance.instance_variable_get(:@property_hash)[:expiration] = @reference_time + 86400
+      expect(instance.expires_soon_or_expired).to be true
+    end
+
+    it 'should return true if expiry time has already passed' do
+      resource = type_class.new(name: 'test', :renewal_threshold => 3, :provider => provider_class.name)
+      instance = provider_class.new(resource)
+      instance.instance_variable_get(:@property_hash)[:expiration] = @reference_time - 86400
+      expect(instance.expires_soon_or_expired).to be true
+    end
+  end
+
+  describe 'needs_reissue?' do
+    before :each do
+      @instance = provider_class.new(name: 'test', :ensure => :present, :cert_data => {
+        'common_name': 'test.example.com',
+      })
+      allow(@instance).to receive(:expires_soon_or_expired).and_return(false)
+    end
+
+    it 'should reissue if it doesn\'t already exist' do
+      @instance.instance_variable_get(:@property_hash)[:ensure] = :absent
+      expect(@instance.needs_issue?). to be true
+    end
+
+    it 'should reissue if the cert_data has changed' do
+      @instance.cert_data = {'common_name': 'test2.example.com'}
+      expect(@instance.needs_issue?). to be true
+    end
+
+    it 'should not reissue if the cert_data is flagged for change but has the same value' do
+      @instance.cert_data = {'common_name': 'test.example.com'}
+      expect(@instance.needs_issue?). to be false
+    end
+
+    it 'should reissue if expires soon or already expired' do
+      allow(@instance).to receive(:expires_soon_or_expired).and_return(true)
+      expect(@instance.needs_issue?). to be true
+    end
+
+    it 'should not reissue if all conditions hold' do
+      expect(@instance.needs_issue?). to be false
+    end
+  end
+
+  describe 'self.get_ca_trust' do
+    before :each do
+      allow(File).to receive(:exist?)
+    end
+
+		#'/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+		#'/etc/ssl/certs/ca-certificates.crt'
+
+    it 'should return find the first certificate bundle when it exists' do
+      allow(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(true)
+      expect(provider_class.get_ca_trust).to eq '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    end
+
+    it 'should return find the second certificate bundle when it exists' do
+      allow(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(false)
+      allow(File).to receive(:exist?).with('/etc/ssl/certs/ca-certificates.crt').and_return(true)
+      expect(provider_class.get_ca_trust).to eq '/etc/ssl/certs/ca-certificates.crt'
+    end
+
+    it 'should raise an error when neither certificate bundle exists' do
+      allow(File).to receive(:exist?).with('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem').and_return(false)
+      allow(File).to receive(:exist?).with('/etc/ssl/certs/ca-certificates.crt').and_return(false)
+      expect do
+        provider_class.get_ca_trust
+      end.to raise_error(Puppet::Error, 'Failed to get the trusted CA certificate file')
+    end
+  end
+
+  describe 'issue_cert' do
+		#http = http_create_secure(uri, ca_trust, @resource[:timeout])
+		#token = vault_get_token(http, @resource[:auth_path].delete('/'))
+		#secrets = vault_http_post(http, uri.path, token, @resource[:cert_data])
+		#response = vault_parse_data(secrets)
+
+    before :each do
+      allow(provider_class).to receive(:get_ca_trust).and_return('/test/ca.crt')
+      allow_any_instance_of(provider_class).to receive(:http_create_secure).and_return(1)
+      allow_any_instance_of(provider_class).to receive(:vault_get_token).and_return('secrettoken')
+      allow_any_instance_of(provider_class).to receive(:vault_http_post).and_return('secrets')
+      allow_any_instance_of(provider_class).to receive(:vault_parse_data).with('secrets').and_return('secrets')
+    end
+
+    it 'should raise an exception when given an invalid URI' do
+      allow(URI).to receive(:new).and_return(double('URI::HTTP', :hostname => nil))
+      resource = type_class.new({:name => 'test', :vault_uri => 'invalid', :provider => provider_class.name})
+      instance = provider_class.new(resource)
+      expect do
+        instance.issue_cert
+      end.to raise_error(Puppet::Error, /Unable to parse a hostname/)
+    end
+
+    it 'should obtain a new cert from vault when given a valid URI' do
+      allow(URI).to receive(:new).and_return(double('URI::HTTP', :hostname => 'vault.example.com', :path => '/'))
+      resource = type_class.new({:name => 'test', :vault_uri => 'http://vault.example.com/pki/issue/cert', :cert_data => {'common_name': 'test.example.com'}, :timeout => 9, :provider => provider_class.name})
+      instance = provider_class.new(resource)
+      expect(instance.issue_cert).to eq 'secrets'
+      expect(instance).to have_received(:http_create_secure).with(URI('http://vault.example.com/pki/issue/cert'), '/test/ca.crt', 9)
+      expect(instance).to have_received(:vault_get_token).with(1, 'puppet-pki')
+      expect(instance).to have_received(:vault_http_post).with(1, '/pki/issue/cert', 'secrettoken', {'common_name': 'test.example.com'})
+      expect(instance).to have_received(:vault_parse_data).with('secrets')
+    end
+  end
+
+  describe 'flush_file_attributes' do
+    [
+      ['info', '/test/vault-secrets/test.json', :info_owner, :info_group, :info_mode],
+      ['ca_chain', '/test/vault-secrets/test.chain.crt', :ca_chain_owner, :ca_chain_group, :ca_chain_mode],
+      ['cert', '/test/vault-secrets/test.crt', :cert_owner, :cert_group, :cert_mode],
+      ['key', '/test/vault-secrets/test.key', :key_owner, :key_group, :key_mode],
+    ].each do |file_attributes|
+      file_name, path, owner, group, mode = file_attributes
+
+      describe "when updating #{file_name} file" do
+        before :each do
+          @resource = type_class.new({:name => 'test', :provider => provider_class.name})
+          @instance = provider_class.new(@resource)
+          allow(provider_class).to receive(:chown_file)
+          allow(provider_class).to receive(:chmod_file)
+        end
+
+        it 'should do nothing when all attributes are in sync' do
+          @instance.flush_file_attributes(path, owner, group, mode, false)
+          expect(provider_class).not_to have_received(:chown_file)
+          expect(provider_class).not_to have_received(:chmod_file)
+        end
+
+        it 'should do nothing when change is signalled to owner but already in sync' do
+          @instance.instance_variable_get(:@property_hash)[owner] = 'testuser'
+          @instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
+          @instance.flush_file_attributes(path, owner, group, mode, false)
+          expect(provider_class).not_to have_received(:chown_file)
+          expect(provider_class).not_to have_received(:chmod_file)
+        end
+
+        it 'should do nothing when change is signalled to group but already in sync' do
+          @instance.instance_variable_get(:@property_hash)[group] = 'testgroup'
+          @instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
+          @instance.flush_file_attributes(path, owner, group, mode, false)
+          expect(provider_class).not_to have_received(:chown_file)
+          expect(provider_class).not_to have_received(:chmod_file)
+        end
+
+        it 'should do nothing when change is signalled to mode but already in sync' do
+          @instance.instance_variable_get(:@property_hash)[mode] = '0600'
+          @instance.instance_variable_get(:@property_flush)[mode] = '0600'
+          @instance.flush_file_attributes(path, owner, group, mode, false)
+          expect(provider_class).not_to have_received(:chown_file)
+          expect(provider_class).not_to have_received(:chmod_file)
+        end
+
+        it 'should update ownership when change is signalled to owner' do
+          @instance.instance_variable_get(:@property_hash)[owner] = 'otheruser'
+          @instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
+          @instance.flush_file_attributes(path, owner, group, mode, false)
+          expect(provider_class).to have_received(:chown_file).with(path, 'testuser', nil)
+          expect(provider_class).not_to have_received(:chmod_file)
+        end
+
+        it 'should update ownership when change is signalled to group' do
+          @instance.instance_variable_get(:@property_hash)[group] = 'othergroup'
+          @instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
+          @instance.flush_file_attributes(path, owner, group, mode, false)
+          expect(provider_class).to have_received(:chown_file).with(path, nil, 'testgroup')
+          expect(provider_class).not_to have_received(:chmod_file)
+        end
+
+        it 'should update permissions when change is signalled' do
+          @instance.instance_variable_get(:@property_hash)[mode] = '0644'
+          @instance.instance_variable_get(:@property_flush)[mode] = '0600'
+          @instance.flush_file_attributes(path, owner, group, mode, false)
+          expect(provider_class).not_to have_received(:chown_file)
+          expect(provider_class).to have_received(:chmod_file).with(path, '0600')
+        end
+
+        it 'should update ownership and mode when change is forced' do
+          @instance.instance_variable_get(:@property_flush)[owner] = 'testuser'
+          @instance.instance_variable_get(:@property_flush)[group] = 'testgroup'
+          @instance.instance_variable_get(:@property_flush)[mode] = '0600'
+          @instance.flush_file_attributes(path, owner, group, mode, true)
+          expect(provider_class).to have_received(:chown_file).with(path, 'testuser', 'testgroup')
+          expect(provider_class).to have_received(:chmod_file).with(path, '0600')
+        end
+      end
+    end
+  end
+
+  describe 'flush_file' do
+    [
+      ['ca_chain', '/test/vault-secrets/test.chain.crt', :ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode],
+      ['cert', '/test/vault-secrets/test.crt', :cert_file, :cert, :cert_owner, :cert_group, :cert_mode],
+      ['key', '/test/vault-secrets/test.key', :key_file, :key, :key_owner, :key_group, :key_mode],
+    ].each do |file_attributes|
+      file_name, target, path, content, owner, group, mode = file_attributes
+
+      describe "when updating #{file_name} file" do
+
+        before :each do
+          allow(File).to receive(:write)
+          @info_file_target = '/test/vault-secrets/test.json'
+          @resource = type_class.new({:name => 'test', path => target, owner => 'testuser', group => 'testgroup', mode => '0600', :provider => provider_class.name})
+          @instance = provider_class.new(@resource)
+          # Derived property can't be set at object creation time due to validation
+          # must be injected into the existing object, as would happen at runtime
+          property_hash = @instance.instance_variable_get(:@property_hash)
+          property_hash[content] = 'testcontent'
+          property_hash[path] = target
+          allow(provider_class).to receive(:delete_if_exists)
+          allow(@instance).to receive(:flush_file_attributes)
+        end
+
+        describe 'should force reset file attributes if the destination file did not previously exist' do
+          it 'because content is not present in property hash' do
+            @instance.instance_variable_get(:@property_hash).delete(content)
+            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            @instance.flush_file(path, content, owner, group, mode)
+            expect(File).to have_received(:write).with(target, 'testcontent')
+            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, true)
+          end
+
+          it 'because content is present in property hash but is nil' do
+            @instance.instance_variable_get(:@property_hash)[content] = nil
+            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            @instance.flush_file(path, content, owner, group, mode)
+            expect(File).to have_received(:write).with(target, 'testcontent')
+            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, true)
+          end
+
+          it 'because content is present in the property hash but is blank' do
+            @instance.instance_variable_get(:@property_hash)[content] = ''
+            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            @instance.flush_file(path, content, owner, group, mode)
+            expect(File).to have_received(:write).with(target, 'testcontent')
+            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, true)
+          end
+        end
+        
+        it 'should force reset file attributes if the file path is being changed' do
+            @instance.instance_variable_get(:@property_hash)[path] = '/test/vault-secrets/old-path.txt'
+            @instance.instance_variable_get(:@property_flush)[path] = target
+            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            @instance.flush_file(path, content, owner, group, mode)
+            expect(File).to have_received(:write).with(target, 'testcontent')
+            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, true)
+        end
+
+        it 'should delete the original file if the path is being changed' do
+            @instance.instance_variable_get(:@property_hash)[path] = '/test/vault-secrets/old-path.txt'
+            @instance.instance_variable_get(:@property_flush)[path] = target
+            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            @instance.flush_file(path, content, owner, group, mode)
+            expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/old-path.txt')
+        end
+
+        it 'should update the file if a change is signalled to the contents' do
+            @instance.instance_variable_get(:@property_hash)[content] = 'oldcontent'
+            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            @instance.flush_file(path, content, owner, group, mode)
+            expect(provider_class).not_to have_received(:delete_if_exists)
+            expect(File).to have_received(:write).with(target, 'testcontent')
+            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, false)
+        end
+
+        it 'should not rewrite the file if a change of contents is signalled but is already in sync' do
+            @instance.instance_variable_get(:@property_hash)[content] = 'testcontent'
+            @instance.instance_variable_get(:@property_flush)[content] = 'testcontent'
+            @instance.flush_file(path, content, owner, group, mode)
+            expect(provider_class).not_to have_received(:delete_if_exists)
+            expect(File).not_to have_received(:write)
+            expect(@instance).to have_received(:flush_file_attributes).with(target, owner, group, mode, false)
+        end
+      end
+    end
+  end
+
+  describe 'flush' do
+    before :each do
+      @resource = type_class.new({
+        :name => 'test',
+        :ensure => :present,
+        :ca_chain_file => '/test/vault-secrets/test.chain.crt',
+        :cert_file => '/test/vault-secrets/test.crt',
+        :key_file => '/test/vault-secrets/test.key',
+        :provider => provider_class.name})
+      @instance = provider_class.new(@resource)
+      allow(provider_class).to receive(:delete_if_exists)
+      allow(@instance).to receive(:flush_file_attributes)
+      allow(@instance).to receive(:flush_file)
+      allow(@instance).to receive(:needs_issue?).and_return(false)
+      allow(@instance).to receive(:issue_cert).and_return({
+        'ca_chain' => ['testchain'],
+        'issuing_ca' => 'testchain',
+        'certificate' => 'testcert',
+        'private_key' => 'testkey',
+      })
+      allow(JSON).to receive(:generate).and_return('testdata')
+      allow(JSON).to receive(:parse).and_return({'data' => { 'ca_chain' => ['testchain'], 'certificate' => 'testcert', 'private_key' => 'testkey'}})
+      allow(File).to receive(:read).and_return('testdata')
+      allow(File).to receive(:write)
+    end
+
+    it 'should delete all files if ensure is set to absent' do
+      @instance.instance_variable_get(:@property_flush)[:ensure] = :absent
+      @instance.flush
+      expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/test.chain.crt')
+      expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/test.crt')
+      expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/test.key')
+      expect(provider_class).to have_received(:delete_if_exists).with('/test/vault-secrets/test.json')
+    end
+    
+    it 'should not delete any files if ensure is not set to absent' do
+      @instance.flush
+      expect(provider_class).not_to have_received(:delete_if_exists)
+    end
+
+    it 'should issue a new cert if needed and update all files' do
+      allow(@instance).to receive(:needs_issue?).and_return(true)
+      @instance.flush
+      expect(@instance).to have_received(:issue_cert)
+      expect(JSON).to have_received(:generate)
+      expect(File).to have_received(:write).with('/test/vault-secrets/test.json', 'testdata')
+      expect(@instance).to have_received(:flush_file_attributes).with('/test/vault-secrets/test.json', :info_owner, :info_group, :info_mode, true)
+      expect(@instance).to have_received(:flush_file).with(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
+      expect(@instance).to have_received(:flush_file).with(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
+      expect(@instance).to have_received(:flush_file).with(:key_file, :key, :key_owner, :key_group, :key_mode)
+    end
+
+    it 'should not issue a new cert if not needed' do
+      @instance.flush
+      expect(@instance).not_to have_received(:issue_cert)
+      expect(File).not_to have_received(:write)
+      expect(File).to have_received(:read).with('/test/vault-secrets/test.json')
+      expect(JSON).to have_received(:parse).with('testdata')
+      expect(@instance).to have_received(:flush_file_attributes).with('/test/vault-secrets/test.json', :info_owner, :info_group, :info_mode)
+      expect(@instance).to have_received(:flush_file).with(:ca_chain_file, :ca_chain, :ca_chain_owner, :ca_chain_group, :ca_chain_mode)
+      expect(@instance).to have_received(:flush_file).with(:cert_file, :cert, :cert_owner, :cert_group, :cert_mode)
+      expect(@instance).to have_received(:flush_file).with(:key_file, :key, :key_owner, :key_group, :key_mode)
+    end
+  end
+end

--- a/spec/unit/provider/ruby_spec.rb
+++ b/spec/unit/provider/ruby_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'spec_helper'
 
 type_class = Puppet::Type.type(:vault_cert)
-provider_class = type_class.provider(:ruby)
+provider_class = type_class.provider(:vault_cert)
 
 describe provider_class do
   let(:resource) do

--- a/spec/unit/type/vault_cert_spec.rb
+++ b/spec/unit/type/vault_cert_spec.rb
@@ -1,0 +1,139 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:vault_cert) do
+  it 'is an instance of Puppet::Type::Vault_cert' do
+    expect(described_class.new(name: 'test')).to be_an_instance_of Puppet::Type::Vault_cert
+  end
+
+  describe 'when validating attributes' do
+    params = [:name, :vault_uri, :auth_path, :timeout, :renewal_threshold]
+    properties = [
+      :cert_data,
+      :info_owner, :info_group, :info_mode,
+      :ca_chain_file, :ca_chain_owner, :ca_chain_group, :ca_chain_mode, :ca_chain, :info_ca_chain,
+      :cert_file, :cert_owner, :cert_group, :cert_mode, :cert, :info_cert,
+      :key_file, :key_owner, :key_group, :key_mode, :key, :info_key,
+      :expiration,
+    ]
+
+    params.each do |param|
+      it "should have the #{param} param" do
+        expect(described_class.attrtype(param)).to eq :param
+      end
+    end
+
+    properties.each do |property|
+      it "should have the #{property} property" do
+        expect(described_class.attrtype(property)).to eq :property
+      end
+    end
+  end
+
+  it 'has name as the namevar' do
+    expect(described_class.key_attributes).to eq [:name]
+  end
+
+  describe 'when validating read-only property' do
+    read_only_properties = [
+      :ca_chain, :cert, :key, :expiration,
+      :info_ca_chain, :info_cert, :info_key,
+    ].freeze
+
+    read_only_properties.each do |prop|
+      context prop.to_s do
+        it 'passes using default auto' do
+          expect do
+            described_class.new(name: 'test', vault_uri: '', cert_data: {})
+          end.not_to raise_error
+        end
+
+        it 'passes using explicit auto' do
+          expect do
+            params = {prop => :auto}
+            described_class.new(name: 'test', vault_uri: '', cert_data: {}, **params)
+          end.not_to raise_error
+        end
+
+        it 'fails using non-auto value' do
+          expect do
+            params = {prop => "foobar"}
+            described_class.new(name: 'test', vault_uri: '', cert_data: {}, **params)
+          end.to raise_error Puppet::Error, %r{Invalid value "foobar"}
+        end
+      end
+    end
+  end
+
+  describe 'when validating insync? on read-only properties' do
+    properties = [
+      :info_ca_chain, :info_cert, :info_key,
+    ].freeze
+
+    properties.each do |prop|
+      context prop.to_s do
+
+        it "is insync always" do
+          resource = described_class.new(name: 'test', vault_uri: '', cert_data: {})
+          expect(resource.property(prop).insync? :auto).to be true
+        end
+      end
+    end
+  end
+
+  describe "when validating insync? on derived properties" do
+    properties = [
+      [:ca_chain, :info_ca_chain],
+      [:cert, :info_cert],
+      [:key, :info_key],
+    ].freeze
+
+    before :each do
+      @class = described_class
+      @provider_class = @class.provide(:fake) { mk_resource_methods }
+      @provider = @provider_class.new
+      allow(@class).to receive(:defaultprovider).and_return(@provider_class)
+      properties.each do |prop|
+        allow(@provider).to receive(prop[1]).and_return('foobar')
+      end
+    end
+
+    properties.each do |prop|
+      context prop[0].to_s do
+
+        it "is insync when #{prop[0]} matches #{prop[1]}" do
+          resource = described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: @provider)
+          expect(resource.property(prop[0]).insync? 'foobar').to be true
+        end
+
+        it "is not insync when #{prop[0]} does not match #{prop[1]}" do
+          resource = described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: @provider)
+          expect(resource.property(prop[0]).insync? 'notfoobar').to be false
+        end
+      end
+    end
+  end
+
+  describe 'when validating certificate expiration' do
+    before :each do
+      @class = described_class
+      @provider_class = @class.provide(:fake) { mk_resource_methods }
+      @provider = @provider_class.new
+      allow(@class).to receive(:defaultprovider).and_return(@provider_class)
+      @resource = described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: @provider)
+    end
+
+    context 'which is not expiring or expired' do
+      it 'should be in sync' do
+        allow(@provider).to receive(:expires_soon_or_expired).and_return(false)
+        expect(@resource.property(:expiration).insync? 'unused').to be true
+      end
+    end
+
+    context 'which is expiring or expired' do
+      it 'should not be in sync' do
+        allow(@provider).to receive(:expires_soon_or_expired).and_return(true)
+        expect(@resource.property(:expiration).insync? 'unused').to be false
+      end
+    end
+  end
+end

--- a/spec/unit/type/vault_cert_spec.rb
+++ b/spec/unit/type/vault_cert_spec.rb
@@ -13,17 +13,17 @@ describe Puppet::Type.type(:vault_cert) do
       :ca_chain_file, :ca_chain_owner, :ca_chain_group, :ca_chain_mode, :ca_chain, :info_ca_chain,
       :cert_file, :cert_owner, :cert_group, :cert_mode, :cert, :info_cert,
       :key_file, :key_owner, :key_group, :key_mode, :key, :info_key,
-      :expiration,
+      :expiration
     ]
 
     params.each do |param|
-      it "should have the #{param} param" do
+      it "has the #{param} param" do
         expect(described_class.attrtype(param)).to eq :param
       end
     end
 
     properties.each do |property|
-      it "should have the #{property} property" do
+      it "has the #{property} property" do
         expect(described_class.attrtype(property)).to eq :property
       end
     end
@@ -36,29 +36,29 @@ describe Puppet::Type.type(:vault_cert) do
   describe 'when validating read-only property' do
     read_only_properties = [
       :ca_chain, :cert, :key, :expiration,
-      :info_ca_chain, :info_cert, :info_key,
+      :info_ca_chain, :info_cert, :info_key
     ].freeze
 
     read_only_properties.each do |prop|
       context prop.to_s do
         it 'passes using default auto' do
-          expect do
+          expect {
             described_class.new(name: 'test', vault_uri: '', cert_data: {})
-          end.not_to raise_error
+          }.not_to raise_error
         end
 
         it 'passes using explicit auto' do
-          expect do
-            params = {prop => :auto}
+          expect {
+            params = { prop => :auto }
             described_class.new(name: 'test', vault_uri: '', cert_data: {}, **params)
-          end.not_to raise_error
+          }.not_to raise_error
         end
 
         it 'fails using non-auto value' do
-          expect do
-            params = {prop => "foobar"}
+          expect {
+            params = { prop => 'foobar' }
             described_class.new(name: 'test', vault_uri: '', cert_data: {}, **params)
-          end.to raise_error Puppet::Error, %r{Invalid value "foobar"}
+          }.to raise_error Puppet::Error, %r{Invalid value "foobar"}
         end
       end
     end
@@ -66,73 +66,73 @@ describe Puppet::Type.type(:vault_cert) do
 
   describe 'when validating insync? on read-only properties' do
     properties = [
-      :info_ca_chain, :info_cert, :info_key,
+      :info_ca_chain, :info_cert, :info_key
     ].freeze
 
     properties.each do |prop|
       context prop.to_s do
-
-        it "is insync always" do
+        it 'is insync always' do
           resource = described_class.new(name: 'test', vault_uri: '', cert_data: {})
-          expect(resource.property(prop).insync? :auto).to be true
+          expect(resource.property(prop).insync?(:auto)).to be true
         end
       end
     end
   end
 
-  describe "when validating insync? on derived properties" do
+  describe 'when validating insync? on derived properties' do
     properties = [
       [:ca_chain, :info_ca_chain],
       [:cert, :info_cert],
       [:key, :info_key],
     ].freeze
 
+    let(:cls) { described_class }
+    let(:provider_class) { cls.provide(:fake) { mk_resource_methods } }
+    let(:provider) { provider_class.new }
+
     before :each do
-      @class = described_class
-      @provider_class = @class.provide(:fake) { mk_resource_methods }
-      @provider = @provider_class.new
-      allow(@class).to receive(:defaultprovider).and_return(@provider_class)
+      allow(cls).to receive(:defaultprovider).and_return(provider_class)
       properties.each do |prop|
-        allow(@provider).to receive(prop[1]).and_return('foobar')
+        allow(provider).to receive(prop[1]).and_return('foobar')
       end
     end
 
     properties.each do |prop|
       context prop[0].to_s do
-
         it "is insync when #{prop[0]} matches #{prop[1]}" do
-          resource = described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: @provider)
-          expect(resource.property(prop[0]).insync? 'foobar').to be true
+          resource = described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: provider)
+          expect(resource.property(prop[0]).insync?('foobar')).to be true
         end
 
         it "is not insync when #{prop[0]} does not match #{prop[1]}" do
-          resource = described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: @provider)
-          expect(resource.property(prop[0]).insync? 'notfoobar').to be false
+          resource = described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: provider)
+          expect(resource.property(prop[0]).insync?('notfoobar')).to be false
         end
       end
     end
   end
 
   describe 'when validating certificate expiration' do
+    let(:cls) { described_class }
+    let(:provider_class) { cls.provide(:fake) { mk_resource_methods } }
+    let(:provider) { provider_class.new }
+    let(:resource) { described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: provider) }
+
     before :each do
-      @class = described_class
-      @provider_class = @class.provide(:fake) { mk_resource_methods }
-      @provider = @provider_class.new
-      allow(@class).to receive(:defaultprovider).and_return(@provider_class)
-      @resource = described_class.new(name: 'test', vault_uri: '', cert_data: {}, provider: @provider)
+      allow(cls).to receive(:defaultprovider).and_return(provider_class)
     end
 
     context 'which is not expiring or expired' do
-      it 'should be in sync' do
-        allow(@provider).to receive(:expires_soon_or_expired).and_return(false)
-        expect(@resource.property(:expiration).insync? 'unused').to be true
+      it 'is in sync' do
+        allow(provider).to receive(:expires_soon_or_expired).and_return(false)
+        expect(resource.property(:expiration).insync?('unused')).to be true
       end
     end
 
     context 'which is expiring or expired' do
-      it 'should not be in sync' do
-        allow(@provider).to receive(:expires_soon_or_expired).and_return(true)
-        expect(@resource.property(:expiration).insync? 'unused').to be false
+      it 'is not in sync' do
+        allow(provider).to receive(:expires_soon_or_expired).and_return(true)
+        expect(resource.property(:expiration).insync?('unused')).to be false
       end
     end
   end


### PR DESCRIPTION
Add support for deploying arbitrary certificates issued by vault for consumption by other applications managed by puppet
* Includes `vault_cert` resource type and provider
* Includes a full test suite
* Includes a manifest to deploy prerequisites and handle optional orphaned resource purging
* Updates REFERENCE and README docs with usage example

Fixes #2