### PR TITLE
fix approle_agent vault-token.service

### DIFF
--- a/manifests/approle_agent.pp
+++ b/manifests/approle_agent.pp
@@ -154,12 +154,10 @@ define vault_secrets::approle_agent (
     }
 
     systemd::unit_file { "${title}-vault-token.service":
-      enable  => true,
-      active  => true,
       content => @("END"),
                  # FILE MANAGED BY PUPPET
                  [Service]
-                 Type=simple
+                 Type=oneshot
                  ExecStart=/bin/chown ${owner} ${sink_file}
                  |END
     }


### PR DESCRIPTION
The `$name-vault-token.service` in `approle_agent.pp` containing a `chmod`and getting triggered by `$name-vault-token.path` shouldn't be a simple service configured to be enabled and running at all times, but a oneshot service that's only started when `$name-vault-token.path` triggers it.