### PR TITLE
Fix expired certificate renewal

### DIFF
--- a/lib/puppet/provider/vault_cert/vault_cert.rb
+++ b/lib/puppet/provider/vault_cert/vault_cert.rb
@@ -226,6 +226,10 @@ Puppet::Type.type(:vault_cert).provide(:vault_cert) do
     @property_flush[:key_mode] = value
   end
 
+  def expiration=(value)
+    # Property should be read only, do not change
+  end
+
   def ca_chain=(value); end
 
   def cert=(value); end


### PR DESCRIPTION
The expiration property should be read-only, but we use a hack to
allow it to trigger a refresh once the cert passes the renewal
threshold. Previously the implicit setter function would allow
puppet to override the value of the expiration property as read
from the system with the magic value `:auto`. This would prevent
the expiration check from functioning.

This change overrides the setter method so that the value of
expiration is never actually changed in the provider state. Since
the expiration is not a property we directly manage, it does not
matter that we are suppressing the change. It does mean the concrete
expiration timestamp of the certificate is always available, which
makes later checks if the certificate is still valid work and
return the correct result.