### PR TITLE
replace delete_suffix with gsub

### DIFF
--- a/lib/puppet_x/vault_secrets/vault.rb
+++ b/lib/puppet_x/vault_secrets/vault.rb
@@ -172,7 +172,7 @@ class Vault
     http.key = OpenSSL::PKey::RSA.new(File.read(hostprivkey))
 
     # Submit the request to the auth_path login endpoint
-    response = post("/v1/auth/#{auth_path.delete_suffix('/')}/login")
+    response = post("/v1/auth/#{auth_path.gsub(/\/$/, '')}/login")
     err_check(response)
 
     # Extract the token value from the response


### PR DESCRIPTION
`String#delete_prefix` doesn't exist on older ruby (puppet) versions (puppet 5 in my case).
Replaced it with gsub, which works.

Other option would be that this module drops support for versions < 6, but I would not encourage that.