### PR TITLE
Optionally allow targeting a cert auth role name

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ include vault_secrets::vault_cert
 vault_cert { 'test':
   ensure            => present,
   vault_uri         => 'https://vault.example.com:8200/v1/pki/issue/role',
+  auth_path         => 'puppet-pki', # mount point for the pki auth engine
+  auth_name         => 'puppetCA',   # optionally limit to this auth role name
   cert_data         => {
     'common_name' => 'test.example.com',
     'alt_names'   => ['alias.exmaple.com', 'localhost'].join(','),

--- a/lib/puppet/provider/vault_cert/vault_cert.rb
+++ b/lib/puppet/provider/vault_cert/vault_cert.rb
@@ -110,6 +110,7 @@ Puppet::Type.type(:vault_cert).provide(:vault_cert) do
     connection = {
       'uri'       => @resource[:vault_uri],
       'auth_path' => @resource[:auth_path],
+      'auth_name' => @resource[:auth_name],
       'ca_trust'  => ca_trust,
       'timeout'   => @resource[:timeout],
     }

--- a/lib/puppet/type/vault_cert.rb
+++ b/lib/puppet/type/vault_cert.rb
@@ -17,6 +17,14 @@ Puppet::Type.newtype(:vault_cert) do
     defaultto 'puppet-pki'
   end
 
+  newparam(:auth_name) do
+    desc 'The named certificate role used to authenticate puppet agent to vault'
+    # defaults to unset, which means vault will try to match the client
+    # against all defined certificate roles. It may be necessary to set this
+    # if a client would match multiple roles to ensure the correct one is used
+    #defaultto nil
+  end
+
   newparam(:timeout) do
     desc 'Length of time to wait on vault connections'
     defaultto 5


### PR DESCRIPTION
Vault allows cert auth logins to target a specific role name by
passing the `name` parameter in the login payload. When omitted,
Vault will compare the client certificate against all cert role
definitions and allow login if any of them match. When provided,
Vault will check only that one cert role.

This might be useful if multiple roles are defined with conflicting
options to ensure the desired one is matched during login.