### PR TITLE
try to JSON::parse values from vault_hiera_hash

### DIFF
--- a/lib/puppet/functions/vault_hiera_hash.rb
+++ b/lib/puppet/functions/vault_hiera_hash.rb
@@ -17,6 +17,7 @@ Puppet::Functions.create_function(:vault_hiera_hash) do
   end
 
   require "#{File.dirname(__FILE__)}/../../puppet_x/vault_secrets/vaultsession.rb"
+  require "json"
 
   def vault_hiera_hash(options, context)
     err_message = "The vault_hiera_hash function requires one of 'uri' or 'uris'"
@@ -42,6 +43,14 @@ Puppet::Functions.create_function(:vault_hiera_hash) do
     data = VaultSession.new(connection).get
 
     context.not_found if data.empty? || !data.is_a?(Hash)
+    unless context.not_found
+      data.each do |key, value|
+        begin
+          data[key] = JSON.parse(value)
+        rescue JSON::ParserError
+        end
+      end
+    end
     context.cache_all(data)
     data
   end

--- a/lib/puppet/functions/vault_hiera_hash.rb
+++ b/lib/puppet/functions/vault_hiera_hash.rb
@@ -42,8 +42,9 @@ Puppet::Functions.create_function(:vault_hiera_hash) do
     # Use the Vault class for the lookup
     data = VaultSession.new(connection).get
 
-    context.not_found if data.empty? || !data.is_a?(Hash)
-    unless context.not_found
+    not_found = data.empty? || !data.is_a?(Hash)
+    context.not_found if not_found
+    unless not_found
       data.each do |key, value|
         begin
           data[key] = JSON.parse(value)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "southalc-vault_secrets",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "author": "Chris Southall",
   "summary": "Work with secrets from Hashicorp Vault",
   "license": "Apache-2.0",


### PR DESCRIPTION
Hi, I found that this little addition works very well for my use case, do you think it's good in general?

# Goal
Allow storing hashes in the vault as json, they can then be retrieved _as hashes_ and even merged by the puppet lookup_option strategy = "deep".

# Example
## 1. Store part of a hash in the vault
```bash
vault kv patch -mount=secret puppet config='{"global": {"password": "supersecret"}}'
```

## 2. Not all of it is secret, so I can store the rest in yaml
```yaml
---
lookup_options:
  config:
    merge:
      strategy: deep

config:
  global:
    log: 'file'
    ipv4: true
    ipv6: true
```

## 3. Output
```bash
puppet lookup config --merge deep --environment production --explain
```
```
[...]
    Merged result: {
      "global" => {
        "log" => "file",
        "ipv4" => true,
        "ipv6" => true,
        "password" => "supersecret"
      }
    }
```

# Benefits
Mainly this avoids writing puppet code to handle this situation, and keeps all the data operations in hiera, reusing the merge strategy concept.