### PR TITLE
Fix approle services

### DIFF
--- a/manifests/approle_agent.pp
+++ b/manifests/approle_agent.pp
@@ -130,8 +130,6 @@ define vault_secrets::approle_agent (
     }
 
     systemd::unit_file { "${title}-vault-token.service":
-      enable  => true,
-      active  => true,
       content => epp('vault_secrets/token_service.epp', {
           owner     => $owner,
           sink_file => $sink_file,

--- a/templates/agent_service.epp
+++ b/templates/agent_service.epp
@@ -5,7 +5,7 @@ Description=Vault agent - <%= $name %>
 Wants=<%= $name %>-vault-token.path
 
 [Service]
-PIDFile=/run/vault/vault-agent.pid
+PIDFile=/run/vault/<%= $name %>_vault-agent.pid
 ExecStart=/usr/bin/vault agent -config=/etc/vault/<%= $name %>_agent.json
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
* Fixed the pid file in vault-agent service
* removed `active` and `enable` parameters on vault-token service, which where causing puppet to start this oneshot service on every puppet run