### PR TITLE
fix typo in v1/v2 checking

### DIFF
--- a/lib/puppet_x/vault_secrets/vaultsession.rb
+++ b/lib/puppet_x/vault_secrets/vaultsession.rb
@@ -121,7 +121,7 @@ class VaultSession
     err_message = "Failed to parse #{version} key/value data from response body: (#{@uri_path})"
     Puppet.debug err_message if output.nil?
     v1_warn = "Data from '#{@uri_path}' was requested as key/value v2, but may be v1 or empty."
-    Puppet.debug v1_warn if @version == 'v2' && outpupt && output.empty?
+    Puppet.debug v1_warn if @version == 'v2' && output && output.empty?
     v2_warn = "Data from '#{@uri_path}' appears to be key/value v2, but was requested as v1"
     Puppet.debug v2_warn if @version == 'v1' && output && output.dig('data') && output.dig('metadata')
     raise Puppet::Error, err_message if output.nil? && fail_hard


### PR DESCRIPTION
Looks like there was a small breaking change in recent changes that I happened to stumble upon. 

Lookups that hit this unfortunate condition throw `Error: Could not run: undefined local variable or method `outpupt' for an instance of VaultSession`

Just fixing the bug for now since there does not seem to be existing test coverage for this. Will circle back to that soon, time permitting.

Validated that with this fix, lookups meeting this condition do still pass with the debug logged as expected.