### PR TITLE
Support numeric certificate ownership

### DIFF
--- a/lib/puppet/provider/vault_cert/vault_cert.rb
+++ b/lib/puppet/provider/vault_cert/vault_cert.rb
@@ -113,8 +113,16 @@ Puppet::Type.type(:vault_cert).provide(:vault_cert) do
     if file && File.exist?(file)
       content = File.read(file)
       stat = File::Stat.new(file)
-      owner = Etc.getpwuid(stat.uid).name
-      group = Etc.getgrgid(stat.gid).name
+      owner = begin
+                Etc.getpwuid(stat.uid).name
+              rescue ArgumentError
+                stat.uid
+              end
+      group = begin
+                Etc.getgrgid(stat.gid).name
+              rescue ArgumentError
+                stat.gid
+              end
       mode = '%04o' % (stat.mode & 0o7777)
       [content, owner, group, mode]
     else
@@ -123,8 +131,8 @@ Puppet::Type.type(:vault_cert).provide(:vault_cert) do
   end
 
   def self.chown_file(file, owner, group)
-    uid = owner ? Etc.getpwnam(owner).uid : nil
-    gid = group ? Etc.getgrnam(group).gid : nil
+    uid = owner.is_a?(String) ? Etc.getpwnam(owner).uid : owner
+    gid = group.is_a?(String) ? Etc.getgrnam(group).gid : group
     File.chown(uid, gid, file) unless uid.nil? && gid.nil?
   end
 

--- a/spec/unit/provider/vault_cert/vault_cert_spec.rb
+++ b/spec/unit/provider/vault_cert/vault_cert_spec.rb
@@ -103,6 +103,17 @@ describe provider_class do
         'testcontent', 'testuser', 'testgroup', '0644'
       ]
     end
+
+    it 'returns numeric IDs when the user and group cannot be resolved' do
+      file = '/test/vault-secrets/test.json'
+      allow(File).to receive(:exist?).with(file).and_return(true)
+      allow(File).to receive(:read).with(file).and_return('testcontent')
+      allow(File::Stat).to receive(:new).with(file).and_return(instance_double('File::Stat', uid: 123, gid: 456, mode: 0o10644))
+      allow(Etc).to receive(:getpwuid).with(123).and_raise(ArgumentError)
+      allow(Etc).to receive(:getgrgid).with(456).and_raise(ArgumentError)
+
+      expect(provider_class.load_file(file)).to eq ['testcontent', 123, 456, '0644']
+    end
   end
 
   describe 'self.chown_file' do
@@ -117,6 +128,14 @@ describe provider_class do
       expect(File).to receive(:chown).with(123, 123, '/test/vault-secrets/test.json')
 
       provider_class.chown_file('/test/vault-secrets/test.json', 'testuser', 'testgroup')
+    end
+
+    it 'changes file ownership and group when given numeric IDs' do
+      expect(Etc).not_to receive(:getpwnam)
+      expect(Etc).not_to receive(:getgrnam)
+      expect(File).to receive(:chown).with(123, 456, '/test/vault-secrets/test.json')
+
+      provider_class.chown_file('/test/vault-secrets/test.json', 123, 456)
     end
 
     it 'changes file ownership when given user only' do


### PR DESCRIPTION
Dropping all changes in my fork except what I found strictly necessary, to realign to this upstream.

I will propose just two pull requests.

1.

Allow vault_cert file properties to use numeric UID and GID values, which is required for docker container and user-namespace ownership.
Preserve numeric IDs when existing file owners cannot be resolved through the local account database.

Keep the existing named user and group behavior unchanged.
Add tests for both numeric assignment and unresolved ownership.