### PR TITLE
Update facterdb and dependencies to fix spec tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,9 @@ group :development do
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 2.1',                      require: false
+  gem "facterdb", '~> 3.10',                     require: false
   gem "metadata-json-lint", '~> 4.0',            require: false
-  gem "rspec-puppet-facts", '~> 4.0',            require: false
+  gem "rspec-puppet-facts", '~> 5.0',            require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false


### PR DESCRIPTION
Test suite was failing with:

```
Error. Invalid JSON given

An error occurred while loading ./spec/defines/approle_agent_spec.rb.
Failure/Error:
    on_supported_os.each do |os, os_facts|
      context "on #{os}" do
        let(:facts) { os_facts }

        it { is_expected.to compile }
      end
    end

NoMethodError:
  undefined method `map' for nil:NilClass
```

LLM identified root cause as facterdb-2.1 shipping a JSON file with an invalid escaped windows filesystem path.

    The failure has nothing to do with this module's code or specs. The root cause is a corrupt data file shipped inside the facterdb 2.1.0 gem.
    The chain of events:
    1. Your spec calls on_supported_os (from rspec-puppet-facts), which asks facterdb for fact sets.
    2. facterdb concatenates all 234 of its bundled .facts files into a single JSON database and hands it to JGrep.jgrep to filter (facterdb.rb:149).
    3. One of those files — facterdb-2.1.0/facts/4.3/windows-2012 r2-x86_64.facts, line 135 — contains invalid JSON: the path value has C:\Windows\system32 with a single backslash before system32. \s is not a valid JSON escape (every other segment correctly uses \\).
    4. Because the whole database is parsed as one blob, that single malformed file makes JGrep fail to parse everything. It prints Error. Invalid JSON given to stderr and returns nil.
    5. facterdb.rb:150 then calls .map on that nil → undefined method 'map' for nil:NilClass, which surfaces up through on_supported_os and aborts loading the spec

Updating the facterdb gem to the latest 3.x (avoids a newer ruby dependency), and bringing rspec-puppet-facts along to match allows the full test suite to run once more.