### PR TITLE
Load selected CA bundles robustly

### DIFF
--- a/lib/puppet_x/vault_secrets/vaultsession.rb
+++ b/lib/puppet_x/vault_secrets/vaultsession.rb
@@ -12,8 +12,8 @@ class VaultSession
     # @param [Hash] args Configuration options for the Vault connection.
     # @option args [String] :uri Required The URL of a Vault API endpoint
     # @option args [Integer] :timeout Optional Seconds to wait for connection attempts. (5)
-    # @option args [Boolean] :secure Optional When true, security certificates will be validated against the 'ca_file' (true)
-    # @option args [String] :ca_file Optional path to a file containing the trusted certificate authority chain.
+    # @option args [Boolean] :secure Optional When true, server certificates will be validated against the trusted CA store. (true)
+    # @option args [String] :ca_trust Optional path to a trusted CA bundle. Defaults to a supported system CA bundle.
     # @option args [String] :token Optional token used to access the Vault API, otherwise attempts certificate authentication using the Puppet agent certificate.
     # @option args [String] :auth_path The Vault path of the "cert" authentication type for Puppet certificates
     # @option args [String] :auth_name The optional Vault certificate named role to authenticate against
@@ -49,7 +49,7 @@ class VaultSession
                  end
       http.use_ssl = true
       http.ssl_version = :TLSv1_2
-      http.ca_file = get_ca_file(ca_trust)
+      http.cert_store = get_cert_store(get_ca_file(ca_trust))
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     elsif @uri.scheme == 'https'
       http.use_ssl = true
@@ -200,19 +200,43 @@ class VaultSession
   end
 
   def get_ca_file(ca_trust)
-    # @summary Try known paths for trusted CA certificates when not specified
-    # @param [String] :ca_trust The path to a trusted certificate authority file. If nil, some defaults are attempted.
-    # @return [String] The verified file path to a trusted certificate authority file.
-    ca_file = if ca_trust && File.exist?(ca_trust)
-                ca_trust
-              elsif File.exist?('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')
-                '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
-              elsif File.exist?('/etc/ssl/certs/ca-certificates.crt')
-                '/etc/ssl/certs/ca-certificates.crt'
-              else
-                nil
-              end
-    raise Puppet::Error, 'Failed to get the trusted CA certificate file.' if ca_file.nil?
+    # @summary Select an explicit trusted CA bundle or an existing supported system bundle.
+    # @param [String] ca_trust An explicit CA bundle path.
+    # @return [String] The selected CA bundle path.
+    if ca_trust
+      raise Puppet::Error, "Trusted CA certificate file does not exist: #{ca_trust}" unless File.file?(ca_trust)
+
+      return ca_trust
+    end
+
+    ca_file = [
+      '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
+      '/etc/ssl/certs/ca-certificates.crt',
+    ].find { |path| File.file?(path) }
+    raise Puppet::Error, 'Failed to get the trusted CA certificate file.' unless ca_file
+
     ca_file
+  end
+
+  def get_cert_store(ca_bundle)
+    # @summary Load trusted CA certificates while tolerating bundle comments, duplicates, and malformed entries.
+    # @param [String] ca_bundle The selected CA bundle path.
+    # @return [OpenSSL::X509::Store] A certificate store containing every valid certificate from the bundle.
+    raise Puppet::Error, "Trusted CA certificate file does not exist: #{ca_bundle}" unless File.file?(ca_bundle)
+
+    store = OpenSSL::X509::Store.new
+    loaded = 0
+    File.read(ca_bundle).scan(%r{-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----}m).each do |pem|
+      store.add_cert(OpenSSL::X509::Certificate.new(pem))
+      loaded += 1
+    rescue OpenSSL::X509::CertificateError => e
+      Puppet.debug "Skipping malformed certificate in #{ca_bundle}: #{e.message}"
+    rescue OpenSSL::X509::StoreError
+      # Duplicate certificates do not need to be added twice.
+    end
+
+    raise Puppet::Error, "No valid CA certificates found in: #{ca_bundle}" if loaded.zero?
+
+    store
   end
 end

--- a/spec/unit/puppet_x/vault_secrets/vault_session_spec.rb
+++ b/spec/unit/puppet_x/vault_secrets/vault_session_spec.rb
@@ -1,0 +1,139 @@
+require 'spec_helper'
+require 'tempfile'
+
+require_relative '../../../../lib/puppet_x/vault_secrets/vaultsession'
+
+describe VaultSession do
+  subject(:session) { described_class.allocate }
+
+  let(:certificate) do
+    key = OpenSSL::PKey::RSA.new(2048)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = OpenSSL::X509::Name.parse('/CN=Spec CA')
+    cert.issuer = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now
+    cert.not_after = Time.now + 3600
+    cert.sign(key, OpenSSL::Digest.new('SHA256'))
+    cert
+  end
+
+  def with_bundle(contents)
+    Tempfile.create('ca-bundle') do |file|
+      file.write(contents)
+      file.flush
+      yield file.path
+    end
+  end
+
+  it 'loads certificates from a bundle containing comments' do
+    with_bundle("# managed certificate bundle\n#{certificate.to_pem}") do |path|
+      store = session.get_cert_store(path)
+
+      expect(store.verify(certificate)).to be true
+    end
+  end
+
+  it 'ignores duplicate certificates' do
+    with_bundle(certificate.to_pem * 2) do |path|
+      store = session.get_cert_store(path)
+
+      expect(store.verify(certificate)).to be true
+    end
+  end
+
+  it 'skips malformed certificates when a valid certificate remains' do
+    malformed = "-----BEGIN CERTIFICATE-----\ninvalid\n-----END CERTIFICATE-----\n"
+    with_bundle("#{malformed}#{certificate.to_pem}") do |path|
+      store = session.get_cert_store(path)
+
+      expect(store.verify(certificate)).to be true
+    end
+  end
+
+  it 'rejects an empty bundle' do
+    with_bundle('') do |path|
+      expect {
+        session.get_cert_store(path)
+      }.to raise_error(Puppet::Error, %r{No valid CA certificates found})
+    end
+  end
+
+  it 'rejects a bundle containing only malformed certificates' do
+    malformed = "-----BEGIN CERTIFICATE-----\ninvalid\n-----END CERTIFICATE-----\n"
+    with_bundle(malformed) do |path|
+      expect {
+        session.get_cert_store(path)
+      }.to raise_error(Puppet::Error, %r{No valid CA certificates found})
+    end
+  end
+
+  it 'rejects a missing explicit bundle' do
+    expect {
+      session.get_cert_store('/missing/ca-bundle.pem')
+    }.to raise_error(Puppet::Error, %r{does not exist})
+  end
+
+  it 'uses an explicitly supplied CA bundle' do
+    allow(File).to receive(:file?).with('/explicit/ca-bundle.pem').and_return(true)
+
+    expect(session.get_ca_file('/explicit/ca-bundle.pem')).to eq '/explicit/ca-bundle.pem'
+  end
+
+  it 'rejects a missing explicitly supplied CA bundle' do
+    allow(File).to receive(:file?).with('/missing/ca-bundle.pem').and_return(false)
+
+    expect {
+      session.get_ca_file('/missing/ca-bundle.pem')
+    }.to raise_error(Puppet::Error, %r{does not exist})
+  end
+
+  it 'preserves upstream system bundle selection when no bundle is supplied' do
+    redhat_bundle = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    debian_bundle = '/etc/ssl/certs/ca-certificates.crt'
+    allow(File).to receive(:file?).with(redhat_bundle).and_return(false)
+    allow(File).to receive(:file?).with(debian_bundle).and_return(true)
+
+    expect(session.get_ca_file(nil)).to eq debian_bundle
+  end
+
+  it 'prefers the Red Hat system bundle when both system bundles exist' do
+    redhat_bundle = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    debian_bundle = '/etc/ssl/certs/ca-certificates.crt'
+    allow(File).to receive(:file?).with(redhat_bundle).and_return(true)
+    allow(File).to receive(:file?).with(debian_bundle).and_return(true)
+
+    expect(session.get_ca_file(nil)).to eq redhat_bundle
+  end
+
+  it 'rejects missing system bundles when no bundle is supplied' do
+    redhat_bundle = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    debian_bundle = '/etc/ssl/certs/ca-certificates.crt'
+    allow(File).to receive(:file?).with(redhat_bundle).and_return(false)
+    allow(File).to receive(:file?).with(debian_bundle).and_return(false)
+
+    expect {
+      session.get_ca_file(nil)
+    }.to raise_error(Puppet::Error, %r{Failed to get the trusted CA certificate file})
+  end
+
+  it 'assigns the selected certificate store to a secure HTTP connection' do
+    http = instance_double(Net::HTTP)
+    store = instance_double(OpenSSL::X509::Store)
+    allow(Net::HTTP).to receive(:new).and_return(http)
+    allow(http).to receive(:open_timeout=)
+    allow(http).to receive(:read_timeout=)
+    allow(http).to receive(:use_ssl=)
+    allow(http).to receive(:ssl_version=)
+    allow(http).to receive(:verify_mode=)
+    allow(session).to receive(:get_cert_store).and_return(store)
+    allow(session).to receive(:get_ca_file).and_return('/etc/ssl/certs/ca-certificates.crt')
+    allow(http).to receive(:cert_store=)
+
+    session.send(:initialize, 'uri' => 'https://vault.example.test', 'token' => 'token')
+
+    expect(http).to have_received(:cert_store=).with(store)
+  end
+end


### PR DESCRIPTION
Update number 2 from my fork. And the last proposal from my side.
We discussed this once and it was not accepted, I hope this simpler and clearer implementation can be considered for merging.

# Problem

Some certificate bundles (for instance those created by freeipa or other system management apps) include comments, duplicates, or anyway extra content that makes calling `http.ca_file = get_ca_file(ca_trust)` fail to create a proper certificate verification file.

Behind the scenes, this delegates PEM-bundle parsing to Net::HTTP/OpenSSL. 

# Solution

The new implementation instead parses the selected bundle itself into an `OpenSSL::X509::Store` and assigns it with:

```
http.cert_store = get_cert_store(get_ca_file(ca_trust))
```

This lets us ignore comments, duplicates, and malformed certificate blocks while retaining valid certificates.

# Tests

Test coverage has been expanded substantially to exercise the new CA-bundle handling

# Behavior changes
While I preserve backward-compatible behavior for valid inputs:
  - Same ca_trust parameter
  - Same Red Hat/Debian fallback paths and order
  - Same HTTP verification behavior
  - Same handling of valid PEM bundles

The following scenarios are handled differently:
  - An explicitly supplied missing path now raises an error instead of silently falling back.
  - Empty or unusable bundles now raise a clear error.
  - Comments, duplicates, and malformed certificate blocks are tolerated.
  - Directories passed as ca_trust are rejected instead of being treated as existing paths.
  
  
# Bonus

corrects the stale documentation from ca_file to ca_trust in the comments